### PR TITLE
enhancements for testing

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -72,7 +72,7 @@ Have fun and let me know what needs to be fixed / added.
 == Testing
 You can invoke a series of minitest based spec test using the supplied
 tests and rake task. Simply run the following to kick off the tests
-@rake test@
+@bundle exec rake test@
 
 You should see output similar to the following (The number of tests will
 of course grow over time):

--- a/README.textile
+++ b/README.textile
@@ -80,3 +80,8 @@ of course grow over time):
 
 If you get any failures, you should of course address them
 
+Since the test suite requires a working Zenoss installation to test against,
+some docker files are provided under test/docker. From a docker host, clone this
+repo, cd to the appropriate test/docker/ subdirectory, and run @sh start.sh@ to
+build and start the container. Once the container is running, you should be able
+to run the tests as described above.

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,9 @@
 require 'rubygems'
 require 'rake/clean'
-require 'rake/gempackagetask'
-require 'rake/rdoctask'
+require 'rubygems/package_task'
+require 'rdoc/task'
 require 'rake/testtask'
+require 'date'
 
 CLEAN.include("pkg")
 CLEAN.include("doc")
@@ -33,8 +34,8 @@ GEMSPEC = Gem::Specification.new do |gem|
   gem.add_runtime_dependency  'tzinfo'
   gem.post_install_message	= "See README.rdoc"
 end
- 
-Rake::GemPackageTask.new(GEMSPEC) do |pkg|
+
+Gem::PackageTask.new(GEMSPEC) do |pkg|
   pkg.need_tar = true
 end
 

--- a/test/docker/3.2.1/Dockerfile
+++ b/test/docker/3.2.1/Dockerfile
@@ -1,0 +1,11 @@
+FROM centos:5
+RUN mkdir /opt/zenoss
+WORKDIR /opt/zenoss
+RUN yum -y install mysql-server net-snmp net-snmp-utils gmp \
+    libgomp libgcj liberation-fonts libaio wget
+RUN wget http://downloads.sourceforge.net/project/zenoss/zenoss-3.2/zenoss-3.2.1/zenoss-3.2.1.el5.x86_64.rpm
+RUN service mysqld start && mysqladmin -u root password '' && \
+    mysqladmin -u root -h localhost password ''
+RUN rpm -ivh ./zenoss-3.2.1.el5.x86_64.rpm
+RUN service zenoss start
+ADD remote_start.sh ./

--- a/test/docker/3.2.1/remote_start.sh
+++ b/test/docker/3.2.1/remote_start.sh
@@ -1,0 +1,3 @@
+service mysqld start
+service zenoss start
+tail -F /opt/zenoss/log/event.log

--- a/test/docker/3.2.1/start.sh
+++ b/test/docker/3.2.1/start.sh
@@ -1,0 +1,2 @@
+docker build -t zen3.2.1 .
+docker run -i -p 8080:8080 -t zen3.2.1 sh remote_start.sh

--- a/test/docker/4.2.5/Dockerfile
+++ b/test/docker/4.2.5/Dockerfile
@@ -1,0 +1,10 @@
+FROM centos:6
+RUN mkdir /opt/zenoss
+WORKDIR /opt/zenoss
+RUN yum -y install wget which
+ADD https://raw.githubusercontent.com/zenoss/core-autodeploy/4.2.5/core-autodeploy.sh ./
+ADD https://raw.githubusercontent.com/zenoss/core-autodeploy/4.2.5/secure_zenoss.sh ./
+ADD https://raw.githubusercontent.com/zenoss/core-autodeploy/4.2.5/zenpack_actions.txt ./
+RUN chmod +x ./core-autodeploy.sh
+RUN echo -e "\ny\n" | ./core-autodeploy.sh
+ADD remote_start.sh ./

--- a/test/docker/4.2.5/remote_start.sh
+++ b/test/docker/4.2.5/remote_start.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+service zenoss start &
+service mysql start &
+service rabbitmq-server start
+rabbitmqctl stop_app
+rabbitmqctl reset
+rabbitmqctl start_app
+rabbitmqctl add_vhost "/zenoss"
+rabbitmqctl add_user zenoss \
+            "$(sed -n 's/amqppassword \(.*\)/\1/p' /opt/zenoss/etc/global.conf)"
+rabbitmqctl set_permissions -p "/zenoss" zenoss ".*" ".*" ".*"
+tail -F /opt/zenoss/log/event.log

--- a/test/docker/4.2.5/start.sh
+++ b/test/docker/4.2.5/start.sh
@@ -1,0 +1,2 @@
+docker build -t zen4.2.5 .
+docker run -i -p 8080:8080 -t zen4.2.5 sh remote_start.sh

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,6 @@
 $:.unshift File.join(File.dirname(__FILE__),'..','lib')
 #http://net.tutsplus.com/tutorials/ruby/ruby-for-newbies-testing-with-rspec/
 require_relative '../lib/zenoss'
-require 'test/unit'
 
 
 ZENOSS_URL = ENV['zenoss_client_url'] || "http://localhost:8080/zport/dmd"

--- a/test/zenoss_client_test.rb
+++ b/test/zenoss_client_test.rb
@@ -1,5 +1,6 @@
 require_relative './test_helper'
 require 'minitest/spec'
+require 'minitest/autorun'
 require 'logger'
 
 LOG = Logger.new(STDOUT)

--- a/zenoss_client.gemspec
+++ b/zenoss_client.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency  'httpclient', '~> 2.2.0'
   gem.add_runtime_dependency  'tzinfo', '~> 0.3.20'
   gem.add_runtime_dependency  'json', '~> 1.5'
-  
+
+  gem.add_development_dependency('rake')
   gem.add_development_dependency('minitest')
 end


### PR DESCRIPTION
Add docker configs to start local instances of Zenoss 3.2 and 4.2 for testing, and update tests to run in a recent Ruby environment. With these changes I was able to verify that 3.2.1 passes the test suite and 4.2.5 fails as described in #11 and #12. After merging #12, the test suite passes on both versions of Zenoss. I also tested on 4.2.1 but the results were the same as 4.2.5 so I didn't make another docker config (also the installation scripts for any version below 4.2.5 don't seem to work).

A next step could be to record interactions with VCR or similar and replay during tests. This would allow us to do regression testing without needing a live Zenoss instance. It should also make it much easier to set up CI.