### PR TITLE
relax httpclient dependency

### DIFF
--- a/zenoss_client.gemspec
+++ b/zenoss_client.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = %w(README.textile COPYING.txt)
 
   gem.required_ruby_version	= '>= 1.8.7'
-  gem.add_runtime_dependency  'httpclient', '~> 2.2.0'
+  gem.add_runtime_dependency  'httpclient', '~> 2.0'
   gem.add_runtime_dependency  'tzinfo', '~> 0.3.20'
   gem.add_runtime_dependency  'json', '~> 1.5'
   


### PR DESCRIPTION
tested with httpclient 2.6.0.1 on zenoss 4.2.5 and 3.2.1