### PR TITLE
enable travis and add secure rubygems source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: ruby
+script: rake test
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.0
+  - ruby-head
+  - jruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec


### PR DESCRIPTION
This PR enables basic CI. Unfortunately [all tests fail](https://travis-ci.org/skrobul/zenoss_client/builds/63407784) and I don't expect this to change until we introduce `vcr` or similar tool.