### PR TITLE
allow connections to be created without signing in

### DIFF
--- a/lib/zenoss.rb
+++ b/lib/zenoss.rb
@@ -32,8 +32,8 @@ module Zenoss
 
   # initialize a connection to a Zenoss server. This is the same as doing
   #   Zenoss::Connection.new(server,user,pass)
-  def Zenoss.connect(server, user, pass, &block)
-    Connection.new(server,user,pass,&block)
+  def Zenoss.connect(server, user, pass, opts = {}, &block)
+    Connection.new(server, user, pass, opts, &block)
   end
 
   # Some of the REST methods return Strings that are formated like a Python list.

--- a/lib/zenoss/connection.rb
+++ b/lib/zenoss/connection.rb
@@ -31,13 +31,13 @@ module Zenoss
     include Zenoss::JSONAPI::ReportRouter
     include Zenoss::RESTAPI
 
-    def initialize(url, user, pass, &block)
+    def initialize(url, user, pass, opts = {}, &block)
       @zenoss_uri = (url.is_a?(URI) ? url : URI.parse(url))
       @request_number = 1
       @httpcli = HTTPClient.new
       @httpcli.receive_timeout = 360  # six minutes should be more that sufficient
       yield(@httpcli) if block_given?
-      sign_in(user,pass)
+      sign_in(user, pass) unless opts[:no_sign_in]
     end
 
     private


### PR DESCRIPTION
(via `:no_sign_in` option) and to sign in later (by making `#sign_in`
public). This allows a session to be shared across multiple processes by
using an external cookie store. Existing invocations of `Zenoss.connect`
and `Connection.new` should be unaffected.