### PR TITLE
vcr: ignore hostname while replaying recordings

### DIFF
--- a/test/fixtures/vcr_cassettes/3_2_1_initial_connection.yml
+++ b/test/fixtures/vcr_cassettes/3_2_1_initial_connection.yml
@@ -2,17 +2,17 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/acl_users/cookieAuthHelper/login
+    uri: http://192.168.56.2:9080/zport/dmd/zport/acl_users/cookieAuthHelper/login
     body:
       encoding: UTF-8
-      string: __ac_name=test&__ac_password=test&submitted=true&came_from=http%3A%2F%2F192.168.56.2%3A9080%2Fzport%2Fdmd%2Fzport%2Fdmd
+      string: __ac_name=admin&__ac_password=zenoss&submitted=true&came_from=http%3A%2F%2F192.168.56.2%3A9080%2Fzport%2Fdmd%2Fzport%2Fdmd
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:03 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Type:
       - application/x-www-form-urlencoded
   response:
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:03 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Length:
       - '59'
       Content-Type:
@@ -31,29 +31,29 @@ http_interactions:
       Location:
       - http://192.168.56.2:9080/zport/dmd/zport/dmd?submitted=true
       Set-Cookie:
-      - __ginger_snap="NzQ2NTczNzQ6NzQ2NTczNzQ%253D"; Path=/
+      - __ginger_snap="NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D"; Path=/
     body:
       encoding: UTF-8
       string: http://192.168.56.2:9080/zport/dmd/zport/dmd?submitted=true
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:03 GMT
+  recorded_at: Fri, 22 May 2015 12:19:38 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/http://192.168.56.2:9080/zport/dmd/zport/dmd?submitted=true
+    uri: http://192.168.56.2:9080/zport/dmd/http://192.168.56.2:9080/zport/dmd/zport/dmd?submitted=true
     body:
       encoding: UTF-8
-      string: __ac_name=test&__ac_password=test&submitted=true&came_from=http%3A%2F%2F192.168.56.2%3A9080%2Fzport%2Fdmd%2Fzport%2Fdmd
+      string: __ac_name=admin&__ac_password=zenoss&submitted=true&came_from=http%3A%2F%2F192.168.56.2%3A9080%2Fzport%2Fdmd%2Fzport%2Fdmd
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:03 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -62,9 +62,9 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:03 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Length:
-      - '23061'
+      - '23063'
       Content-Type:
       - text/html; charset=utf-8
     body:
@@ -265,7 +265,7 @@ http_interactions:
         id=\"header-extra\">\n                                <div id=\"searchbox-container\"></div>\n
         \                               <div id=\"saved-search-container\"></div>\n
         \                               <div id=\"user-link-container\">\n                                    <a\n
-        \   href=\"/zport/dmd/ZenUsers/test\">\n                                    test\n
+        \   href=\"/zport/dmd/ZenUsers/admin\">\n                                    admin\n
         \                                   </a>\n                                </div>\n
         \                               <div id=\"sign-out-link\">\n                                    <a
         href=\"/zport/dmd/logoutUser\">sign out</a>\n                                </div>\n
@@ -291,7 +291,7 @@ http_interactions:
         \       connect('dialog_close','onclick', mydialog.box.hide);\n        $('dialog').style.visibility
         = '';\n    }\n});\n</script>\n\n\n    \n        <div id=\"contentPaneContainer\">\n
         \           \n<div id=\"portletContainer\"></div>\n<script>\n    var start_time
-        = '2015-05-22 09:18:03';\n    var state = '';\n    if(state) var dashboardState
+        = '2015-05-22 12:19:38';\n    var state = '';\n    if(state) var dashboardState
         = evalJSON(state);\n</script>\n<script>\nvar server_time = isoTimestamp(start_time).getTime();\nvar
         updateTime = {\n    run: function () {\n        server_time += 1000;\n    },\n
         \   interval: 1000\n}\nExt.TaskMgr.start(updateTime);\n\nfunction getServerTimestamp()
@@ -356,10 +356,10 @@ http_interactions:
         type=\"text/javascript\">\nExt.History.init(function(mgr){\n    Ext.History.selectByToken(mgr.getToken());\n});\n</script>\n</body>\n</html>
         <!-- metal:use-macro=\"context/page_macros/base-new\" -->\n\n\n"
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:03 GMT
+  recorded_at: Fri, 22 May 2015 12:19:38 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
       string: '[{"action":"DeviceRouter","method":"addDevice","data":[{"deviceName":"UnitTestDevice","deviceClass":"/Devices/Server"}],"type":"rpc","tid":1}]'
@@ -369,11 +369,11 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:03 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -382,7 +382,7 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:03 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Length:
       - '176'
       Content-Type:
@@ -390,12 +390,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"tid": 1, "action": "DeviceRouter", "type": "rpc", "method": "addDevice",
-        "result": {"success": true, "jobId": "DeviceCreationJobStatus_f6e8bdd9-de2f-4771-83b5-e11e77dd65b0"}}'
+        "result": {"success": true, "jobId": "DeviceCreationJobStatus_77b6d227-2f37-4260-a016-0892d66ad838"}}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:03 GMT
+  recorded_at: Fri, 22 May 2015 12:19:38 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
       string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":2}]'
@@ -405,11 +405,11 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:03 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -418,122 +418,14 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:03 GMT
-      Content-Length:
-      - '149'
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      string: '{"tid": 2, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
-        "result": {"totalCount": 0, "hash": "0", "success": true, "devices": []}}'
-    http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:03 GMT
-- request:
-    method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
-    body:
-      encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":3}]'
-    headers:
-      User-Agent:
-      - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
-      Accept:
-      - "*/*"
-      Date:
-      - Fri, 22 May 2015 09:18:18 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
-      Date:
-      - Fri, 22 May 2015 09:18:18 GMT
-      Content-Length:
-      - '149'
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      string: '{"tid": 3, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
-        "result": {"totalCount": 0, "hash": "0", "success": true, "devices": []}}'
-    http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:18 GMT
-- request:
-    method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
-    body:
-      encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":4}]'
-    headers:
-      User-Agent:
-      - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
-      Accept:
-      - "*/*"
-      Date:
-      - Fri, 22 May 2015 09:18:33 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
-      Date:
-      - Fri, 22 May 2015 09:18:33 GMT
-      Content-Length:
-      - '149'
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      string: '{"tid": 4, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
-        "result": {"totalCount": 0, "hash": "0", "success": true, "devices": []}}'
-    http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:33 GMT
-- request:
-    method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
-    body:
-      encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":5}]'
-    headers:
-      User-Agent:
-      - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
-      Accept:
-      - "*/*"
-      Date:
-      - Fri, 22 May 2015 09:18:48 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
-      Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Length:
       - '576'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"tid": 5, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
+      string: '{"tid": 2, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"groups":
         [], "serialNumber": "", "name": "UnitTestDevice", "collector": "localhost",
         "osModel": null, "productionState": "Production", "location": null, "priority":
@@ -541,5 +433,5 @@ http_interactions:
         [], "hwManufacturer": null, "ipAddress": null, "events": {"info": 0, "debug":
         0, "critical": 0, "warning": 0, "error": 0}, "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice"}]}}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:48 GMT
+  recorded_at: Fri, 22 May 2015 12:19:38 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/3_2_1_test_0001_returns_an_Array_of_devices_when_searched_by_name.yml
+++ b/test/fixtures/vcr_cassettes/3_2_1_test_0001_returns_an_Array_of_devices_when_searched_by_name.yml
@@ -2,21 +2,21 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":17}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":11}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -25,14 +25,14 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Length:
       - '577'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"tid": 17, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
+      string: '{"tid": 11, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"groups":
         [], "serialNumber": "", "name": "UnitTestDevice", "collector": "localhost",
         "osModel": null, "productionState": "Production", "location": null, "priority":
@@ -40,24 +40,24 @@ http_interactions:
         [], "hwManufacturer": null, "ipAddress": null, "events": {"info": 0, "debug":
         0, "critical": 0, "warning": 0, "error": 0}, "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice"}]}}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:49 GMT
+  recorded_at: Fri, 22 May 2015 12:19:39 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":18}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":12}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -66,14 +66,14 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Length:
       - '577'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"tid": 18, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
+      string: '{"tid": 12, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"groups":
         [], "serialNumber": "", "name": "UnitTestDevice", "collector": "localhost",
         "osModel": null, "productionState": "Production", "location": null, "priority":
@@ -81,5 +81,5 @@ http_interactions:
         [], "hwManufacturer": null, "ipAddress": null, "events": {"info": 0, "debug":
         0, "critical": 0, "warning": 0, "error": 0}, "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice"}]}}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:49 GMT
+  recorded_at: Fri, 22 May 2015 12:19:39 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/3_2_1_test_0002_returns_device_uptime_when_asked.yml
+++ b/test/fixtures/vcr_cassettes/3_2_1_test_0002_returns_device_uptime_when_asked.yml
@@ -2,21 +2,21 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":8}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":17}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -25,14 +25,14 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Length:
-      - '576'
+      - '577'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"tid": 8, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
+      string: '{"tid": 17, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"groups":
         [], "serialNumber": "", "name": "UnitTestDevice", "collector": "localhost",
         "osModel": null, "productionState": "Production", "location": null, "priority":
@@ -40,10 +40,10 @@ http_interactions:
         [], "hwManufacturer": null, "ipAddress": null, "events": {"info": 0, "debug":
         0, "critical": 0, "warning": 0, "error": 0}, "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice"}]}}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:48 GMT
+  recorded_at: Fri, 22 May 2015 12:19:39 GMT
 - request:
     method: get
-    uri: http://localhost:8080/zport/dmd/zport/dmd/Devices/Server/devices/UnitTestDevice/sysUpTime
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/Devices/Server/devices/UnitTestDevice/sysUpTime
     body:
       encoding: UTF-8
       string: ''
@@ -53,9 +53,9 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -64,7 +64,7 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Length:
       - '2'
       Content-Type:
@@ -73,10 +73,10 @@ http_interactions:
       encoding: UTF-8
       string: "-1"
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:48 GMT
+  recorded_at: Fri, 22 May 2015 12:19:39 GMT
 - request:
     method: get
-    uri: http://localhost:8080/zport/dmd/zport/dmd/Devices/Server/devices/UnitTestDevice/sysUpTime
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/Devices/Server/devices/UnitTestDevice/sysUpTime
     body:
       encoding: UTF-8
       string: ''
@@ -86,9 +86,9 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -97,7 +97,7 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Length:
       - '2'
       Content-Type:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: "-1"
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:48 GMT
+  recorded_at: Fri, 22 May 2015 12:19:39 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/3_2_1_test_0003_returns_an_Array_of_events_for_a_device.yml
+++ b/test/fixtures/vcr_cassettes/3_2_1_test_0003_returns_an_Array_of_events_for_a_device.yml
@@ -2,21 +2,21 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":13}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":5}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -25,14 +25,14 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Length:
-      - '577'
+      - '576'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"tid": 13, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
+      string: '{"tid": 5, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"groups":
         [], "serialNumber": "", "name": "UnitTestDevice", "collector": "localhost",
         "osModel": null, "productionState": "Production", "location": null, "priority":
@@ -40,24 +40,24 @@ http_interactions:
         [], "hwManufacturer": null, "ipAddress": null, "events": {"info": 0, "debug":
         0, "critical": 0, "warning": 0, "error": 0}, "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice"}]}}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:48 GMT
+  recorded_at: Fri, 22 May 2015 12:19:38 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/evconsole_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/evconsole_router
     body:
       encoding: UTF-8
-      string: '[{"action":"EventsRouter","method":"query","data":[{"limit":100,"start":0,"sort":"lastTime","dir":"DESC","uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":14}]'
+      string: '[{"action":"EventsRouter","method":"query","data":[{"limit":100,"start":0,"sort":"lastTime","dir":"DESC","uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":6}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -66,15 +66,15 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Length:
-      - '142'
+      - '141'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"tid": 14, "action": "EventsRouter", "type": "rpc", "method": "query",
-        "result": {"totalCount": 0, "events": [], "asof": 1432286328.8653319}}'
+      string: '{"tid": 6, "action": "EventsRouter", "type": "rpc", "method": "query",
+        "result": {"totalCount": 0, "events": [], "asof": 1432297178.8344669}}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:48 GMT
+  recorded_at: Fri, 22 May 2015 12:19:38 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/3_2_1_test_0004_returns_an_Array_of_historical_events_for_a_device.yml
+++ b/test/fixtures/vcr_cassettes/3_2_1_test_0004_returns_an_Array_of_historical_events_for_a_device.yml
@@ -2,21 +2,21 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":11}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":7}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -25,14 +25,14 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Length:
-      - '577'
+      - '576'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"tid": 11, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
+      string: '{"tid": 7, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"groups":
         [], "serialNumber": "", "name": "UnitTestDevice", "collector": "localhost",
         "osModel": null, "productionState": "Production", "location": null, "priority":
@@ -40,24 +40,24 @@ http_interactions:
         [], "hwManufacturer": null, "ipAddress": null, "events": {"info": 0, "debug":
         0, "critical": 0, "warning": 0, "error": 0}, "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice"}]}}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:48 GMT
+  recorded_at: Fri, 22 May 2015 12:19:38 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/evconsole_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/evconsole_router
     body:
       encoding: UTF-8
-      string: '[{"action":"EventsRouter","method":"query","data":[{"limit":100,"start":0,"sort":"lastTime","dir":"DESC","uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":12}]'
+      string: '[{"action":"EventsRouter","method":"query","data":[{"limit":100,"start":0,"sort":"lastTime","dir":"DESC","uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":8}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -66,15 +66,15 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Length:
-      - '142'
+      - '141'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"tid": 12, "action": "EventsRouter", "type": "rpc", "method": "query",
-        "result": {"totalCount": 0, "events": [], "asof": 1432286328.8309741}}'
+      string: '{"tid": 8, "action": "EventsRouter", "type": "rpc", "method": "query",
+        "result": {"totalCount": 0, "events": [], "asof": 1432297178.8653581}}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:48 GMT
+  recorded_at: Fri, 22 May 2015 12:19:38 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/3_2_1_test_0005_returns_info_for_a_device_in_the_form_of_a_Hash.yml
+++ b/test/fixtures/vcr_cassettes/3_2_1_test_0005_returns_info_for_a_device_in_the_form_of_a_Hash.yml
@@ -2,21 +2,21 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":19}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":13}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -25,14 +25,14 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Length:
       - '577'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"tid": 19, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
+      string: '{"tid": 13, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"groups":
         [], "serialNumber": "", "name": "UnitTestDevice", "collector": "localhost",
         "osModel": null, "productionState": "Production", "location": null, "priority":
@@ -40,24 +40,24 @@ http_interactions:
         [], "hwManufacturer": null, "ipAddress": null, "events": {"info": 0, "debug":
         0, "critical": 0, "warning": 0, "error": 0}, "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice"}]}}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:49 GMT
+  recorded_at: Fri, 22 May 2015 12:19:39 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getInfo","data":[{"uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":20}]'
+      string: '[{"action":"DeviceRouter","method":"getInfo","data":[{"uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":14}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -66,14 +66,14 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Length:
       - '2772'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"tid": 20, "action": "DeviceRouter", "type": "rpc", "method": "getInfo",
+      string: '{"tid": 14, "action": "DeviceRouter", "type": "rpc", "method": "getInfo",
         "result": {"disabled": false, "data": {"productionState": "Production", "uid":
         "/zport/dmd/Devices/Server/devices/UnitTestDevice", "links": "", "snmpContact":
         "", "osModel": null, "hwModel": null, "osManufacturer": null, "deviceClass":
@@ -104,29 +104,29 @@ http_interactions:
         "lastCollected": "1970/01/01 00:00:00", "events": {"info": 0, "debug": 0,
         "critical": 0, "warning": 0, "error": 0}, "systems": [], "status": true, "description":
         "", "snmpDescr": "", "groups": [], "device": "UnitTestDevice", "firstSeen":
-        "2015/05/22 09:18:44", "icon": "/zport/dmd/img/icons/server.png", "snmpSysName":
-        "", "lastChanged": "2015/05/22 09:18:49", "serialNumber": "", "tagNumber":
+        "2015/05/22 11:17:52", "icon": "/zport/dmd/img/icons/server.png", "snmpSysName":
+        "", "lastChanged": "2015/05/22 11:44:50", "serialNumber": "", "tagNumber":
         "", "meta_type": "Device", "inspector_type": "Device", "snmpLocation": "",
         "snmpAgent": "", "ipAddress": null, "rackSlot": 0}, "success": true}}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:49 GMT
+  recorded_at: Fri, 22 May 2015 12:19:39 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getInfo","data":[{"uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":21}]'
+      string: '[{"action":"DeviceRouter","method":"getInfo","data":[{"uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":15}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -135,14 +135,14 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Length:
       - '2772'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"tid": 21, "action": "DeviceRouter", "type": "rpc", "method": "getInfo",
+      string: '{"tid": 15, "action": "DeviceRouter", "type": "rpc", "method": "getInfo",
         "result": {"disabled": false, "data": {"productionState": "Production", "uid":
         "/zport/dmd/Devices/Server/devices/UnitTestDevice", "links": "", "snmpContact":
         "", "osModel": null, "hwModel": null, "osManufacturer": null, "deviceClass":
@@ -173,29 +173,29 @@ http_interactions:
         "lastCollected": "1970/01/01 00:00:00", "events": {"info": 0, "debug": 0,
         "critical": 0, "warning": 0, "error": 0}, "systems": [], "status": true, "description":
         "", "snmpDescr": "", "groups": [], "device": "UnitTestDevice", "firstSeen":
-        "2015/05/22 09:18:44", "icon": "/zport/dmd/img/icons/server.png", "snmpSysName":
-        "", "lastChanged": "2015/05/22 09:18:49", "serialNumber": "", "tagNumber":
+        "2015/05/22 11:17:52", "icon": "/zport/dmd/img/icons/server.png", "snmpSysName":
+        "", "lastChanged": "2015/05/22 11:44:50", "serialNumber": "", "tagNumber":
         "", "meta_type": "Device", "inspector_type": "Device", "snmpLocation": "",
         "snmpAgent": "", "ipAddress": null, "rackSlot": 0}, "success": true}}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:49 GMT
+  recorded_at: Fri, 22 May 2015 12:19:39 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getInfo","data":[{"uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":22}]'
+      string: '[{"action":"DeviceRouter","method":"getInfo","data":[{"uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":16}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -204,14 +204,14 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Length:
       - '2772'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"tid": 22, "action": "DeviceRouter", "type": "rpc", "method": "getInfo",
+      string: '{"tid": 16, "action": "DeviceRouter", "type": "rpc", "method": "getInfo",
         "result": {"disabled": false, "data": {"productionState": "Production", "uid":
         "/zport/dmd/Devices/Server/devices/UnitTestDevice", "links": "", "snmpContact":
         "", "osModel": null, "hwModel": null, "osManufacturer": null, "deviceClass":
@@ -242,10 +242,10 @@ http_interactions:
         "lastCollected": "1970/01/01 00:00:00", "events": {"info": 0, "debug": 0,
         "critical": 0, "warning": 0, "error": 0}, "systems": [], "status": true, "description":
         "", "snmpDescr": "", "groups": [], "device": "UnitTestDevice", "firstSeen":
-        "2015/05/22 09:18:44", "icon": "/zport/dmd/img/icons/server.png", "snmpSysName":
-        "", "lastChanged": "2015/05/22 09:18:49", "serialNumber": "", "tagNumber":
+        "2015/05/22 11:17:52", "icon": "/zport/dmd/img/icons/server.png", "snmpSysName":
+        "", "lastChanged": "2015/05/22 11:44:50", "serialNumber": "", "tagNumber":
         "", "meta_type": "Device", "inspector_type": "Device", "snmpLocation": "",
         "snmpAgent": "", "ipAddress": null, "rackSlot": 0}, "success": true}}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:49 GMT
+  recorded_at: Fri, 22 May 2015 12:19:39 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/3_2_1_test_0006_returns_an_Array_of_events_for_all_devices.yml
+++ b/test/fixtures/vcr_cassettes/3_2_1_test_0006_returns_an_Array_of_events_for_all_devices.yml
@@ -2,21 +2,21 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":23}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":3}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -25,14 +25,14 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Length:
-      - '577'
+      - '576'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"tid": 23, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
+      string: '{"tid": 3, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"groups":
         [], "serialNumber": "", "name": "UnitTestDevice", "collector": "localhost",
         "osModel": null, "productionState": "Production", "location": null, "priority":
@@ -40,24 +40,24 @@ http_interactions:
         [], "hwManufacturer": null, "ipAddress": null, "events": {"info": 0, "debug":
         0, "critical": 0, "warning": 0, "error": 0}, "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice"}]}}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:49 GMT
+  recorded_at: Fri, 22 May 2015 12:19:38 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/evconsole_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/evconsole_router
     body:
       encoding: UTF-8
-      string: '[{"action":"EventsRouter","method":"query","data":[{"limit":100,"start":0,"sort":"lastTime","dir":"DESC"}],"type":"rpc","tid":24}]'
+      string: '[{"action":"EventsRouter","method":"query","data":[{"limit":100,"start":0,"sort":"lastTime","dir":"DESC"}],"type":"rpc","tid":4}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -66,27 +66,21 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Length:
-      - '1059'
+      - '606'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"tid": 24, "action": "EventsRouter", "type": "rpc", "method": "query",
-        "result": {"totalCount": 2, "events": [{"count": "2", "firstTime": "2015-05-22
-        09:16:51", "severity": "4", "evid": "edc74c91-3c36-4b4d-ae99-5e27c81eb6bf",
-        "component": {"text": "zenwin", "uid": null}, "summary": "localhost zenwin
-        heartbeat failure", "eventState": "New", "device": {"text": "07aba008d471",
-        "uid": null}, "eventClass": {"text": "/Status/Heartbeat", "uid": "/zport/dmd/Events/Status/Heartbeat"},
-        "lastTime": "2015-05-22 09:17:51", "id": "edc74c91-3c36-4b4d-ae99-5e27c81eb6bf"},
-        {"count": "1", "firstTime": "2015-05-21 22:38:21", "severity": "4", "evid":
-        "fa1466bd-a707-4d11-af25-b6b0f8ebfa9c", "component": {"text": "snmp", "uid":
-        null}, "summary": "SNMP agent down", "eventState": "New", "device": {"text":
-        "localhost", "uid": "/zport/dmd/Devices/Server/Linux/devices/localhost"},
+      string: '{"tid": 4, "action": "EventsRouter", "type": "rpc", "method": "query",
+        "result": {"totalCount": 1, "events": [{"count": "31", "firstTime": "2015-05-21
+        22:38:21", "severity": "4", "evid": "fa1466bd-a707-4d11-af25-b6b0f8ebfa9c",
+        "component": {"text": "snmp", "uid": null}, "summary": "SNMP agent down",
+        "eventState": "New", "device": {"text": "localhost", "uid": "/zport/dmd/Devices/Server/Linux/devices/localhost"},
         "eventClass": {"text": "/Status/Snmp", "uid": "/zport/dmd/Events/Status/Snmp"},
-        "lastTime": "2015-05-21 22:38:21", "id": "fa1466bd-a707-4d11-af25-b6b0f8ebfa9c"}],
-        "asof": 1432286329.6609261}}'
+        "lastTime": "2015-05-22 11:47:01", "id": "fa1466bd-a707-4d11-af25-b6b0f8ebfa9c"}],
+        "asof": 1432297178.7991951}}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:49 GMT
+  recorded_at: Fri, 22 May 2015 12:19:38 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/3_2_1_test_0007_fetches_the_report_tree.yml
+++ b/test/fixtures/vcr_cassettes/3_2_1_test_0007_fetches_the_report_tree.yml
@@ -2,21 +2,21 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":6}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":9}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -25,14 +25,14 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Length:
       - '576'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"tid": 6, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
+      string: '{"tid": 9, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"groups":
         [], "serialNumber": "", "name": "UnitTestDevice", "collector": "localhost",
         "osModel": null, "productionState": "Production", "location": null, "priority":
@@ -40,24 +40,24 @@ http_interactions:
         [], "hwManufacturer": null, "ipAddress": null, "events": {"info": 0, "debug":
         0, "critical": 0, "warning": 0, "error": 0}, "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice"}]}}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:48 GMT
+  recorded_at: Fri, 22 May 2015 12:19:38 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/report_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/report_router
     body:
       encoding: UTF-8
-      string: '[{"action":"ReportRouter","method":"getTree","data":[{"id":"/zport/dmd/Reports"}],"type":"rpc","tid":7}]'
+      string: '[{"action":"ReportRouter","method":"getTree","data":[{"id":"/zport/dmd/Reports"}],"type":"rpc","tid":10}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:38 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -66,14 +66,14 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Length:
-      - '8396'
+      - '8397'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"tid": 7, "action": "ReportRouter", "type": "rpc", "method": "getTree",
+      string: '{"tid": 10, "action": "ReportRouter", "type": "rpc", "method": "getTree",
         "result": [{"meta_type": "ReportClass", "leaf": false, "uid": "/zport/dmd/Reports",
         "deletable": false, "text": {"count": 19, "text": "Reports", "description":
         "reports"}, "path": "", "expandable": true, "uiProvider": "report", "children":
@@ -177,5 +177,5 @@ http_interactions:
         ".zport.dmd.Reports.User Reports.Notification Schedules"}], "id": ".zport.dmd.Reports.User
         Reports"}], "id": ".zport.dmd.Reports"}]}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:48 GMT
+  recorded_at: Fri, 22 May 2015 12:19:39 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/3_2_1_test_0008_fetches_available_report_types_and_returns_a_Hash.yml
+++ b/test/fixtures/vcr_cassettes/3_2_1_test_0008_fetches_available_report_types_and_returns_a_Hash.yml
@@ -2,21 +2,21 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":9}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":18}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -25,14 +25,14 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Length:
-      - '576'
+      - '577'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"tid": 9, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
+      string: '{"tid": 18, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"groups":
         [], "serialNumber": "", "name": "UnitTestDevice", "collector": "localhost",
         "osModel": null, "productionState": "Production", "location": null, "priority":
@@ -40,24 +40,24 @@ http_interactions:
         [], "hwManufacturer": null, "ipAddress": null, "events": {"info": 0, "debug":
         0, "critical": 0, "warning": 0, "error": 0}, "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice"}]}}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:48 GMT
+  recorded_at: Fri, 22 May 2015 12:19:39 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/report_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/report_router
     body:
       encoding: UTF-8
-      string: '[{"action":"ReportRouter","method":"getReportTypes","data":{},"type":"rpc","tid":10}]'
+      string: '[{"action":"ReportRouter","method":"getReportTypes","data":{},"type":"rpc","tid":19}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -66,17 +66,17 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Length:
       - '259'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"tid": 10, "action": "ReportRouter", "type": "rpc", "method": "getReportTypes",
+      string: '{"tid": 19, "action": "ReportRouter", "type": "rpc", "method": "getReportTypes",
         "result": {"menuText": ["Custom Device Report", "Graph Report", "Multi-Graph
         Report"], "reportTypes": ["customDeviceReport", "graphReport", "multiGraphReport"],
         "success": true}}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:48 GMT
+  recorded_at: Fri, 22 May 2015 12:19:39 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/3_2_1_test_0009_renames_the_device.yml
+++ b/test/fixtures/vcr_cassettes/3_2_1_test_0009_renames_the_device.yml
@@ -2,21 +2,21 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":15}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":20}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -25,14 +25,14 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Length:
       - '577'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"tid": 15, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
+      string: '{"tid": 20, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"groups":
         [], "serialNumber": "", "name": "UnitTestDevice", "collector": "localhost",
         "osModel": null, "productionState": "Production", "location": null, "priority":
@@ -40,10 +40,10 @@ http_interactions:
         [], "hwManufacturer": null, "ipAddress": null, "events": {"info": 0, "debug":
         0, "critical": 0, "warning": 0, "error": 0}, "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice"}]}}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:48 GMT
+  recorded_at: Fri, 22 May 2015 12:19:39 GMT
 - request:
     method: get
-    uri: http://localhost:8080/zport/dmd/zport/dmd/Devices/Server/devices/UnitTestDevice/renameDevice?newId=unit_test_temporary_device_name
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/Devices/Server/devices/UnitTestDevice/renameDevice?newId=unit_test_temporary_device_name
     body:
       encoding: UTF-8
       string: ''
@@ -53,9 +53,9 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:48 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -64,7 +64,7 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Length:
       - '65'
       Content-Type:
@@ -73,24 +73,24 @@ http_interactions:
       encoding: UTF-8
       string: "/zport/dmd/Devices/Server/devices/unit_test_temporary_device_name"
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:49 GMT
+  recorded_at: Fri, 22 May 2015 12:19:39 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"unit_test_temporary_device_name"}}],"type":"rpc","tid":16}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"unit_test_temporary_device_name"}}],"type":"rpc","tid":21}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -99,14 +99,14 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Content-Length:
       - '611'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"tid": 16, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
+      string: '{"tid": 21, "action": "DeviceRouter", "type": "rpc", "method": "getDevices",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"groups":
         [], "serialNumber": "", "name": "unit_test_temporary_device_name", "collector":
         "localhost", "osModel": null, "productionState": "Production", "location":
@@ -114,10 +114,10 @@ http_interactions:
         null, "systems": [], "hwManufacturer": null, "ipAddress": null, "events":
         {"info": 0, "debug": 0, "critical": 0, "warning": 0, "error": 0}, "uid": "/zport/dmd/Devices/Server/devices/unit_test_temporary_device_name"}]}}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:49 GMT
+  recorded_at: Fri, 22 May 2015 12:19:39 GMT
 - request:
     method: get
-    uri: http://localhost:8080/zport/dmd/zport/dmd/Devices/Server/devices/unit_test_temporary_device_name/renameDevice?newId=UnitTestDevice
+    uri: http://192.168.56.2:9080/zport/dmd/zport/dmd/Devices/Server/devices/unit_test_temporary_device_name/renameDevice?newId=UnitTestDevice
     body:
       encoding: UTF-8
       string: ''
@@ -127,9 +127,9 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:39 GMT
       Cookie:
-      - __ginger_snap=NzQ2NTczNzQ6NzQ2NTczNzQ%253D
+      - __ginger_snap=NjE2NDZkNjk2ZTo3YTY1NmU2ZjczNzM%253D
   response:
     status:
       code: 200
@@ -138,7 +138,7 @@ http_interactions:
       Server:
       - Zope/(2.12.1, python 2.6.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:18:49 GMT
+      - Fri, 22 May 2015 12:19:40 GMT
       Content-Length:
       - '48'
       Content-Type:
@@ -147,5 +147,5 @@ http_interactions:
       encoding: UTF-8
       string: "/zport/dmd/Devices/Server/devices/UnitTestDevice"
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:18:49 GMT
+  recorded_at: Fri, 22 May 2015 12:19:40 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/4_2_5_initial_connection.yml
+++ b/test/fixtures/vcr_cassettes/4_2_5_initial_connection.yml
@@ -2,17 +2,17 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/acl_users/cookieAuthHelper/login
+    uri: http://192.168.56.2:8080/zport/dmd/zport/acl_users/cookieAuthHelper/login
     body:
       encoding: UTF-8
-      string: __ac_name=test&__ac_password=test&submitted=true&came_from=http%3A%2F%2F192.168.56.2%3A8080%2Fzport%2Fdmd%2Fzport%2Fdmd
+      string: __ac_name=admin&__ac_password=zenoss&submitted=true&came_from=http%3A%2F%2F192.168.56.2%3A8080%2Fzport%2Fdmd%2Fzport%2Fdmd
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:11 GMT
+      - Fri, 22 May 2015 12:14:20 GMT
       Content-Type:
       - application/x-www-form-urlencoded
   response:
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:11 GMT
+      - Fri, 22 May 2015 12:14:20 GMT
       Content-Length:
       - '59'
       Content-Type:
@@ -31,29 +31,29 @@ http_interactions:
       Location:
       - http://192.168.56.2:8080/zport/dmd/zport/dmd?submitted=true
       Set-Cookie:
-      - _ZopeId="53572535A68vSC9XJhE"; Path=/; HTTPOnly
+      - _ZopeId="47495875A68v.lkNK6o"; Path=/; HTTPOnly
     body:
       encoding: UTF-8
       string: http://192.168.56.2:8080/zport/dmd/zport/dmd?submitted=true
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:11 GMT
+  recorded_at: Fri, 22 May 2015 12:14:20 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/http://192.168.56.2:8080/zport/dmd/zport/dmd?submitted=true
+    uri: http://192.168.56.2:8080/zport/dmd/http://192.168.56.2:8080/zport/dmd/zport/dmd?submitted=true
     body:
       encoding: UTF-8
-      string: __ac_name=test&__ac_password=test&submitted=true&came_from=http%3A%2F%2F192.168.56.2%3A8080%2Fzport%2Fdmd%2Fzport%2Fdmd
+      string: __ac_name=admin&__ac_password=zenoss&submitted=true&came_from=http%3A%2F%2F192.168.56.2%3A8080%2Fzport%2Fdmd%2Fzport%2Fdmd
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:11 GMT
+      - Fri, 22 May 2015 12:14:20 GMT
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -62,9 +62,9 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:11 GMT
+      - Fri, 22 May 2015 12:14:21 GMT
       Content-Length:
-      - '32102'
+      - '31717'
       Content-Type:
       - text/html; charset=utf-8
     body:
@@ -183,7 +183,7 @@ http_interactions:
         {\n\n    YAHOO.zenoss.templateFreeURL = '/zport/dmd';\n    YAHOO.zenoss.ZENOSS_VERSION
         = '4.2.5';\n    YAHOO.zenoss.ZENOSS_PRODUCT = 'core';\n\n});\n\n\n\n</script>\n\n
         \   <link rel=\"stylesheet\" type=\"text/css\" href=\"/++resource++zenui/css/backcompat.css?v=1394581109.0\"
-        />\n\n    \n\n        \n<script type=\"text/javascript\">\nExt.state.Manager.getProvider().setState('{\"device_grid\":{\"columns\":[{\"id\":\"name\"},{\"id\":\"h1\"},{\"id\":\"deviceClass\"},{\"id\":\"productionState\"},{\"id\":\"serialNumber\"},{\"id\":\"tagNumber\"},{\"id\":\"hwManufacturer\"},{\"id\":\"hwModel\"},{\"id\":\"osManufacturer\"},{\"id\":\"osModel\"},{\"id\":\"h2\"},{\"id\":\"priorityString\"},{\"id\":\"h3\"},{\"id\":\"h4\"},{\"id\":\"h5\"},{\"id\":\"worstevents\"}],\"sort\":{\"property\":\"name\",\"direction\":\"ASC\",\"root\":\"data\"},\"filters\":{}}}');\n\n
+        />\n\n    \n\n        \n<script type=\"text/javascript\">\nExt.state.Manager.getProvider().setState('{}');\n\n
         \       Ext.onReady(function(){\n            Zenoss.env.EVENT_CLASSES = ['/App',
         '/App/Apache', '/App/Citrix', '/App/Conn', '/App/Conn/Max', '/App/Email',
         '/App/Email/Loop', '/App/Failed', '/App/Info', '/App/Install', '/App/Job',
@@ -361,7 +361,7 @@ http_interactions:
         \                           <div id=\"header-extra\">\n                                <div
         id=\"searchbox-container\"></div>\n                                <div id=\"saved-search-container\"></div>\n
         \                               <div id=\"user-link-container\">\n                                    <a
-        href=\"/zport/dmd/ZenUsers/test\">\n                                    test\n
+        href=\"/zport/dmd/ZenUsers/admin\">\n                                    admin\n
         \                                   </a>\n                                </div>\n
         \                               <div id=\"sign-out-link\">\n                                    <a
         href=\"/zport/dmd/logoutUser\">sign out</a>\n                                </div>\n
@@ -387,7 +387,7 @@ http_interactions:
         \       connect('dialog_close','onclick', mydialog.box.hide);\n        $('dialog').style.visibility
         = '';\n    }\n});\n</script>\n\n\n    \n        <div id=\"contentPaneContainer\">\n
         \           \n<div id=\"portletContainer\"></div>\n<script>\n    var start_time
-        = '2015-05-22 09:12:11';\n    var state = '';\n    if(state) var dashboardState
+        = '2015-05-22 12:14:21';\n    var state = '';\n    if(state) var dashboardState
         = evalJSON(state);\n</script>\n<script>\nvar server_time = isoTimestamp(start_time).getTime();\nvar
         updateTime = {\n    run: function () {\n        server_time += 1000;\n    },\n
         \   interval: 1000\n}\nExt.TaskManager.start(updateTime);\nif (Ext.isIE) {\n
@@ -470,10 +470,10 @@ http_interactions:
         type=\"text/javascript\">\nExt.History.init(function(mgr){\n    Ext.History.selectByToken(mgr.getToken());\n});\n</script>\n</body>\n</html>
         <!-- metal:use-macro=\"context/page_macros/base-new\" -->\n\n\n"
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:11 GMT
+  recorded_at: Fri, 22 May 2015 12:14:21 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
       string: '[{"action":"DeviceRouter","method":"addDevice","data":[{"deviceName":"UnitTestDevice","deviceClass":"/Devices/Server"}],"type":"rpc","tid":1}]'
@@ -483,11 +483,11 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:11 GMT
+      - Fri, 22 May 2015 12:14:21 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -496,22 +496,22 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:11 GMT
+      - Fri, 22 May 2015 12:14:21 GMT
       Content-Length:
       - '291'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "082a4e42-88c0-4a52-a07e-d1e765b818ed", "action": "DeviceRouter",
-        "result": {"new_jobs": [{"uuid": "3c41d5f0-8df2-4f59-83e9-6e20805bc34a", "description":
+      string: '{"uuid": "837df1fc-de1d-4462-8d87-dc639dd4c1d9", "action": "DeviceRouter",
+        "result": {"new_jobs": [{"uuid": "816000e0-f95e-4c1f-8f79-0213e4653af3", "description":
         "Add device UnitTestDevice", "uid": "/zport/dmd/JobManager"}], "success":
         true}, "tid": 1, "type": "rpc", "method": "addDevice"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:11 GMT
+  recorded_at: Fri, 22 May 2015 12:14:21 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
       string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":2}]'
@@ -521,11 +521,11 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:11 GMT
+      - Fri, 22 May 2015 12:14:21 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -534,21 +534,21 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:11 GMT
+      - Fri, 22 May 2015 12:14:21 GMT
       Content-Length:
       - '197'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "b44da0d1-42f9-43fd-807d-f5ea39f85c45", "action": "DeviceRouter",
+      string: '{"uuid": "45e97034-3550-42db-8ba9-ba931a812e9d", "action": "DeviceRouter",
         "result": {"totalCount": 0, "hash": "0", "success": true, "devices": []},
         "tid": 2, "type": "rpc", "method": "getDevices"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:11 GMT
+  recorded_at: Fri, 22 May 2015 12:14:21 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
       string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":3}]'
@@ -558,11 +558,11 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -571,14 +571,14 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Length:
       - '905'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "d4af070a-2fa6-4a4b-b8f5-07d882613676", "action": "DeviceRouter",
+      string: '{"uuid": "4aa9dc77-6347-4f63-84fd-8d8c908c889b", "action": "DeviceRouter",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
         null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
         null, "collector": "localhost", "osModel": null, "productionState": 1000,
@@ -590,5 +590,5 @@ http_interactions:
         0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
         "name": "UnitTestDevice"}]}, "tid": 3, "type": "rpc", "method": "getDevices"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:26 GMT
+  recorded_at: Fri, 22 May 2015 12:14:36 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/4_2_5_test_0001_returns_an_Array_of_devices_when_searched_by_name.yml
+++ b/test/fixtures/vcr_cassettes/4_2_5_test_0001_returns_an_Array_of_devices_when_searched_by_name.yml
@@ -2,21 +2,21 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":4}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":17}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:37 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -25,14 +25,14 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:37 GMT
       Content-Length:
-      - '905'
+      - '906'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "bf2975c8-a484-4f52-b29f-1d899735d86d", "action": "DeviceRouter",
+      string: '{"uuid": "195e32eb-1d92-4bac-9260-48f72561d8c3", "action": "DeviceRouter",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
         null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
         null, "collector": "localhost", "osModel": null, "productionState": 1000,
@@ -42,26 +42,26 @@ http_interactions:
         "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
         0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
         0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
-        "name": "UnitTestDevice"}]}, "tid": 4, "type": "rpc", "method": "getDevices"}'
+        "name": "UnitTestDevice"}]}, "tid": 17, "type": "rpc", "method": "getDevices"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:26 GMT
+  recorded_at: Fri, 22 May 2015 12:14:37 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":5}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":18}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:37 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -70,14 +70,14 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:37 GMT
       Content-Length:
-      - '905'
+      - '906'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "b8bb2977-b931-40b8-aa45-e1241ace42f4", "action": "DeviceRouter",
+      string: '{"uuid": "9c94307c-db71-43d2-954d-a3cb654f271c", "action": "DeviceRouter",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
         null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
         null, "collector": "localhost", "osModel": null, "productionState": 1000,
@@ -87,7 +87,7 @@ http_interactions:
         "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
         0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
         0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
-        "name": "UnitTestDevice"}]}, "tid": 5, "type": "rpc", "method": "getDevices"}'
+        "name": "UnitTestDevice"}]}, "tid": 18, "type": "rpc", "method": "getDevices"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:26 GMT
+  recorded_at: Fri, 22 May 2015 12:14:37 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/4_2_5_test_0002_returns_device_uptime_when_asked.yml
+++ b/test/fixtures/vcr_cassettes/4_2_5_test_0002_returns_device_uptime_when_asked.yml
@@ -2,21 +2,21 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":14}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":10}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -25,14 +25,14 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Length:
       - '906'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "4c18058e-4fae-4204-8006-f052dc56e192", "action": "DeviceRouter",
+      string: '{"uuid": "24383d45-6737-484a-9a5d-3a3a11264718", "action": "DeviceRouter",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
         null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
         null, "collector": "localhost", "osModel": null, "productionState": 1000,
@@ -42,12 +42,12 @@ http_interactions:
         "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
         0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
         0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
-        "name": "UnitTestDevice"}]}, "tid": 14, "type": "rpc", "method": "getDevices"}'
+        "name": "UnitTestDevice"}]}, "tid": 10, "type": "rpc", "method": "getDevices"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:26 GMT
+  recorded_at: Fri, 22 May 2015 12:14:36 GMT
 - request:
     method: get
-    uri: http://localhost:8080/zport/dmd/zport/dmd/Devices/Server/devices/UnitTestDevice/sysUpTime
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/Devices/Server/devices/UnitTestDevice/sysUpTime
     body:
       encoding: UTF-8
       string: ''
@@ -57,9 +57,9 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -68,7 +68,7 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Length:
       - '3'
       Content-Type:
@@ -77,10 +77,10 @@ http_interactions:
       encoding: UTF-8
       string: nan
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:27 GMT
+  recorded_at: Fri, 22 May 2015 12:14:36 GMT
 - request:
     method: get
-    uri: http://localhost:8080/zport/dmd/zport/dmd/Devices/Server/devices/UnitTestDevice/sysUpTime
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/Devices/Server/devices/UnitTestDevice/sysUpTime
     body:
       encoding: UTF-8
       string: ''
@@ -90,9 +90,9 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:27 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -101,7 +101,7 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Length:
       - '3'
       Content-Type:
@@ -110,5 +110,5 @@ http_interactions:
       encoding: UTF-8
       string: nan
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:27 GMT
+  recorded_at: Fri, 22 May 2015 12:14:36 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/4_2_5_test_0003_returns_an_Array_of_events_for_a_device.yml
+++ b/test/fixtures/vcr_cassettes/4_2_5_test_0003_returns_an_Array_of_events_for_a_device.yml
@@ -2,21 +2,21 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":15}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":11}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:27 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -25,14 +25,14 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Length:
       - '906'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "27bc1120-db55-419e-82b9-f2b4c679ee5a", "action": "DeviceRouter",
+      string: '{"uuid": "ce741537-ab28-42ec-9864-2b938f1c1c8e", "action": "DeviceRouter",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
         null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
         null, "collector": "localhost", "osModel": null, "productionState": 1000,
@@ -42,26 +42,26 @@ http_interactions:
         "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
         0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
         0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
-        "name": "UnitTestDevice"}]}, "tid": 15, "type": "rpc", "method": "getDevices"}'
+        "name": "UnitTestDevice"}]}, "tid": 11, "type": "rpc", "method": "getDevices"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:27 GMT
+  recorded_at: Fri, 22 May 2015 12:14:36 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/evconsole_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/evconsole_router
     body:
       encoding: UTF-8
-      string: '[{"action":"EventsRouter","method":"query","data":[{"limit":100,"start":0,"sort":"lastTime","dir":"DESC","uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":16}]'
+      string: '[{"action":"EventsRouter","method":"query","data":[{"limit":100,"start":0,"sort":"lastTime","dir":"DESC","uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":12}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:27 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -70,30 +70,30 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Length:
       - '1341'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "490e7b70-4fb5-447b-bf3c-6ddf7381a311", "action": "EventsRouter",
+      string: '{"uuid": "ea06b90e-c24d-401e-8b7a-c35b5f48b09e", "action": "EventsRouter",
         "result": {"totalCount": 1, "events": [{"prodState": null, "firstTime": "2015-05-22
-        09:12:02", "facility": null, "eventClassKey": null, "agent": null, "dedupid":
+        12:13:50", "facility": null, "eventClassKey": null, "agent": null, "dedupid":
         "UnitTestDevice||/Change/Remove|2|Deleted device: UnitTestDevice", "Location":
         [], "ownerid": null, "eventClass": {"text": "/Change/Remove", "uid": "/zport/dmd/Events/Change/Remove"},
-        "id": "0242ac11-001e-9740-11e5-00629bc10069", "DevicePriority": null, "monitor":
+        "id": "0242ac11-0025-9742-11e5-007c0173f789", "DevicePriority": null, "monitor":
         null, "priority": null, "details": {}, "DeviceClass": [], "eventKey": "",
-        "evid": "0242ac11-001e-9740-11e5-00629bc10069", "eventClassMapping": "", "component":
+        "evid": "0242ac11-0025-9742-11e5-007c0173f789", "eventClassMapping": "", "component":
         {"url": null, "text": null, "uid": null, "uuid": null}, "clearid": null, "DeviceGroups":
-        [], "eventGroup": null, "device": {"url": "/zport/dmd/goto?guid=b71deecb-3dbc-471e-90f1-3bf947ec121d",
-        "text": "UnitTestDevice", "uuid": "b71deecb-3dbc-471e-90f1-3bf947ec121d",
+        [], "eventGroup": null, "device": {"url": "/zport/dmd/goto?guid=00217159-594e-49da-889c-7650f8329068",
+        "text": "UnitTestDevice", "uuid": "00217159-594e-49da-889c-7650f8329068",
         "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice"}, "message": "Deleted
         device: UnitTestDevice", "severity": 2, "count": 1, "stateChange": "2015-05-22
-        09:12:02", "ntevid": null, "summary": "Deleted device: UnitTestDevice", "eventState":
-        "Closed", "lastTime": "2015-05-22 09:12:02", "ipAddress": "", "Systems": []}],
-        "success": true, "asof": 1432285946.977841}, "tid": 16, "type": "rpc", "method":
+        12:13:50", "ntevid": null, "summary": "Deleted device: UnitTestDevice", "eventState":
+        "Closed", "lastTime": "2015-05-22 12:13:50", "ipAddress": "", "Systems": []}],
+        "success": true, "asof": 1432296876.617308}, "tid": 12, "type": "rpc", "method":
         "query"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:27 GMT
+  recorded_at: Fri, 22 May 2015 12:14:36 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/4_2_5_test_0004_returns_an_Array_of_historical_events_for_a_device.yml
+++ b/test/fixtures/vcr_cassettes/4_2_5_test_0004_returns_an_Array_of_historical_events_for_a_device.yml
@@ -2,21 +2,21 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":12}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":15}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:37 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -25,14 +25,14 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:37 GMT
       Content-Length:
       - '906'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "66e36a20-2c96-4296-a7ac-4965451d2955", "action": "DeviceRouter",
+      string: '{"uuid": "ccecf673-8e59-44fc-b189-706139dec777", "action": "DeviceRouter",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
         null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
         null, "collector": "localhost", "osModel": null, "productionState": 1000,
@@ -42,26 +42,26 @@ http_interactions:
         "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
         0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
         0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
-        "name": "UnitTestDevice"}]}, "tid": 12, "type": "rpc", "method": "getDevices"}'
+        "name": "UnitTestDevice"}]}, "tid": 15, "type": "rpc", "method": "getDevices"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:26 GMT
+  recorded_at: Fri, 22 May 2015 12:14:37 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/evconsole_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/evconsole_router
     body:
       encoding: UTF-8
-      string: '[{"action":"EventsRouter","method":"query","data":[{"limit":100,"start":0,"sort":"lastTime","dir":"DESC","uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":13}]'
+      string: '[{"action":"EventsRouter","method":"query","data":[{"limit":100,"start":0,"sort":"lastTime","dir":"DESC","uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":16}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:37 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -70,30 +70,30 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:37 GMT
       Content-Length:
       - '1341'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "21d79e54-d2ab-4d92-a450-c71e39b449c8", "action": "EventsRouter",
+      string: '{"uuid": "0b0e6f34-140e-489e-af49-89b5d4ff7939", "action": "EventsRouter",
         "result": {"totalCount": 1, "events": [{"prodState": null, "firstTime": "2015-05-22
-        09:12:02", "facility": null, "eventClassKey": null, "agent": null, "dedupid":
+        12:13:50", "facility": null, "eventClassKey": null, "agent": null, "dedupid":
         "UnitTestDevice||/Change/Remove|2|Deleted device: UnitTestDevice", "Location":
         [], "ownerid": null, "eventClass": {"text": "/Change/Remove", "uid": "/zport/dmd/Events/Change/Remove"},
-        "id": "0242ac11-001e-9740-11e5-00629bc10069", "DevicePriority": null, "monitor":
+        "id": "0242ac11-0025-9742-11e5-007c0173f789", "DevicePriority": null, "monitor":
         null, "priority": null, "details": {}, "DeviceClass": [], "eventKey": "",
-        "evid": "0242ac11-001e-9740-11e5-00629bc10069", "eventClassMapping": "", "component":
+        "evid": "0242ac11-0025-9742-11e5-007c0173f789", "eventClassMapping": "", "component":
         {"url": null, "text": null, "uid": null, "uuid": null}, "clearid": null, "DeviceGroups":
-        [], "eventGroup": null, "device": {"url": "/zport/dmd/goto?guid=b71deecb-3dbc-471e-90f1-3bf947ec121d",
-        "text": "UnitTestDevice", "uuid": "b71deecb-3dbc-471e-90f1-3bf947ec121d",
+        [], "eventGroup": null, "device": {"url": "/zport/dmd/goto?guid=00217159-594e-49da-889c-7650f8329068",
+        "text": "UnitTestDevice", "uuid": "00217159-594e-49da-889c-7650f8329068",
         "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice"}, "message": "Deleted
         device: UnitTestDevice", "severity": 2, "count": 1, "stateChange": "2015-05-22
-        09:12:02", "ntevid": null, "summary": "Deleted device: UnitTestDevice", "eventState":
-        "Closed", "lastTime": "2015-05-22 09:12:02", "ipAddress": "", "Systems": []}],
-        "success": true, "asof": 1432285946.850004}, "tid": 13, "type": "rpc", "method":
+        12:13:50", "ntevid": null, "summary": "Deleted device: UnitTestDevice", "eventState":
+        "Closed", "lastTime": "2015-05-22 12:13:50", "ipAddress": "", "Systems": []}],
+        "success": true, "asof": 1432296877.137202}, "tid": 16, "type": "rpc", "method":
         "query"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:26 GMT
+  recorded_at: Fri, 22 May 2015 12:14:37 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/4_2_5_test_0005_returns_info_for_a_device_in_the_form_of_a_Hash.yml
+++ b/test/fixtures/vcr_cassettes/4_2_5_test_0005_returns_info_for_a_device_in_the_form_of_a_Hash.yml
@@ -2,21 +2,21 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":8}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":19}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:37 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -25,14 +25,14 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:37 GMT
       Content-Length:
-      - '905'
+      - '906'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "bf0c7458-9b35-4734-ab38-f8a52c607b4e", "action": "DeviceRouter",
+      string: '{"uuid": "7f910b72-452c-47b7-b65d-2c74b4cda6fe", "action": "DeviceRouter",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
         null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
         null, "collector": "localhost", "osModel": null, "productionState": 1000,
@@ -42,26 +42,26 @@ http_interactions:
         "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
         0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
         0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
-        "name": "UnitTestDevice"}]}, "tid": 8, "type": "rpc", "method": "getDevices"}'
+        "name": "UnitTestDevice"}]}, "tid": 19, "type": "rpc", "method": "getDevices"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:26 GMT
+  recorded_at: Fri, 22 May 2015 12:14:37 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getInfo","data":[{"uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":9}]'
+      string: '[{"action":"DeviceRouter","method":"getInfo","data":[{"uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":20}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:37 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -70,76 +70,14 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
-      Content-Length:
-      - '2197'
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      string: '{"uuid": "7f2afa27-2b06-4ebb-a74f-e7c4a6aa22ff", "action": "DeviceRouter",
-        "result": {"disabled": false, "data": {"productionState": 1000, "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice",
-        "links": "", "snmpContact": "", "osModel": null, "hwModel": null, "osManufacturer":
-        null, "deviceClass": {"uuid": "98db2956-4f5f-42f5-ac1f-173ff47b306d", "name":
-        "/Server", "severity": "error", "id": "Server", "meta_type": "DeviceClass",
-        "inspector_type": "DeviceClass", "path": "/Devices/Server", "uid": "/zport/dmd/Devices/Server",
-        "events": {"info": {"count": 1, "acknowledged_count": 0}, "clear": {"count":
-        0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
-        0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
-        1, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
-        "description": ""}, "hwManufacturer": null, "snmpVersion": "v2c", "collector":
-        "localhost", "id": "UnitTestDevice", "uptime": "Unknown", "severity": "clear",
-        "locking": {"updates": false, "deletion": false, "events": false}, "comments":
-        "", "name": "UnitTestDevice", "priority": 3, "snmpCommunity": "public", "location":
-        null, "memory": {"ram": "Unknown", "swap": "Unknown"}, "icon": "/zport/dmd/img/icons/server.png",
-        "priorityLabel": "Normal", "lastCollected": "Not Modeled", "events": {"info":
-        {"count": 0, "acknowledged_count": 0}, "clear": {"count": 0, "acknowledged_count":
-        0}, "warning": {"count": 0, "acknowledged_count": 0}, "critical": {"count":
-        0, "acknowledged_count": 0}, "error": {"count": 0, "acknowledged_count": 0},
-        "debug": {"count": 0, "acknowledged_count": 0}}, "systems": [], "status":
-        true, "ipAddressString": null, "description": "", "snmpDescr": "", "groups":
-        [], "device": "UnitTestDevice", "firstSeen": "2015/05/22 09:12:11", "snmpSysName":
-        "", "pythonClass": "Products.ZenModel.Device", "lastChanged": "2015/05/22
-        09:12:12", "productionStateLabel": "Production", "serialNumber": "", "uuid":
-        "b71deecb-3dbc-471e-90f1-3bf947ec121d", "tagNumber": "", "meta_type": "Device",
-        "inspector_type": "Device", "snmpLocation": "", "snmpAgent": "", "ipAddress":
-        null, "rackSlot": 0}, "success": true}, "tid": 9, "type": "rpc", "method":
-        "getInfo"}'
-    http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:26 GMT
-- request:
-    method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
-    body:
-      encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getInfo","data":[{"uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":10}]'
-    headers:
-      User-Agent:
-      - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
-      Accept:
-      - "*/*"
-      Date:
-      - Fri, 22 May 2015 09:12:26 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
-      Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:37 GMT
       Content-Length:
       - '2198'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "32b77a46-5c8d-44e4-985d-093fbfc82f49", "action": "DeviceRouter",
+      string: '{"uuid": "e7b5baa4-3626-450b-9798-9f1fbd5a7dc6", "action": "DeviceRouter",
         "result": {"disabled": false, "data": {"productionState": 1000, "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice",
         "links": "", "snmpContact": "", "osModel": null, "hwModel": null, "osManufacturer":
         null, "deviceClass": {"uuid": "98db2956-4f5f-42f5-ac1f-173ff47b306d", "name":
@@ -160,32 +98,32 @@ http_interactions:
         0, "acknowledged_count": 0}, "error": {"count": 0, "acknowledged_count": 0},
         "debug": {"count": 0, "acknowledged_count": 0}}, "systems": [], "status":
         true, "ipAddressString": null, "description": "", "snmpDescr": "", "groups":
-        [], "device": "UnitTestDevice", "firstSeen": "2015/05/22 09:12:11", "snmpSysName":
+        [], "device": "UnitTestDevice", "firstSeen": "2015/05/22 12:14:21", "snmpSysName":
         "", "pythonClass": "Products.ZenModel.Device", "lastChanged": "2015/05/22
-        09:12:12", "productionStateLabel": "Production", "serialNumber": "", "uuid":
-        "b71deecb-3dbc-471e-90f1-3bf947ec121d", "tagNumber": "", "meta_type": "Device",
+        12:14:37", "productionStateLabel": "Production", "serialNumber": "", "uuid":
+        "00217159-594e-49da-889c-7650f8329068", "tagNumber": "", "meta_type": "Device",
         "inspector_type": "Device", "snmpLocation": "", "snmpAgent": "", "ipAddress":
-        null, "rackSlot": 0}, "success": true}, "tid": 10, "type": "rpc", "method":
+        null, "rackSlot": 0}, "success": true}, "tid": 20, "type": "rpc", "method":
         "getInfo"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:26 GMT
+  recorded_at: Fri, 22 May 2015 12:14:37 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getInfo","data":[{"uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":11}]'
+      string: '[{"action":"DeviceRouter","method":"getInfo","data":[{"uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":21}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:37 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -194,14 +132,14 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:37 GMT
       Content-Length:
       - '2198'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "ddc1ec54-542d-4825-b369-d374e80d2f45", "action": "DeviceRouter",
+      string: '{"uuid": "d8be6206-d683-4909-ad26-1b26b47ca08e", "action": "DeviceRouter",
         "result": {"disabled": false, "data": {"productionState": 1000, "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice",
         "links": "", "snmpContact": "", "osModel": null, "hwModel": null, "osManufacturer":
         null, "deviceClass": {"uuid": "98db2956-4f5f-42f5-ac1f-173ff47b306d", "name":
@@ -222,13 +160,75 @@ http_interactions:
         0, "acknowledged_count": 0}, "error": {"count": 0, "acknowledged_count": 0},
         "debug": {"count": 0, "acknowledged_count": 0}}, "systems": [], "status":
         true, "ipAddressString": null, "description": "", "snmpDescr": "", "groups":
-        [], "device": "UnitTestDevice", "firstSeen": "2015/05/22 09:12:11", "snmpSysName":
+        [], "device": "UnitTestDevice", "firstSeen": "2015/05/22 12:14:21", "snmpSysName":
         "", "pythonClass": "Products.ZenModel.Device", "lastChanged": "2015/05/22
-        09:12:12", "productionStateLabel": "Production", "serialNumber": "", "uuid":
-        "b71deecb-3dbc-471e-90f1-3bf947ec121d", "tagNumber": "", "meta_type": "Device",
+        12:14:37", "productionStateLabel": "Production", "serialNumber": "", "uuid":
+        "00217159-594e-49da-889c-7650f8329068", "tagNumber": "", "meta_type": "Device",
         "inspector_type": "Device", "snmpLocation": "", "snmpAgent": "", "ipAddress":
-        null, "rackSlot": 0}, "success": true}, "tid": 11, "type": "rpc", "method":
+        null, "rackSlot": 0}, "success": true}, "tid": 21, "type": "rpc", "method":
         "getInfo"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:26 GMT
+  recorded_at: Fri, 22 May 2015 12:14:37 GMT
+- request:
+    method: post
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/device_router
+    body:
+      encoding: UTF-8
+      string: '[{"action":"DeviceRouter","method":"getInfo","data":[{"uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":22}]'
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
+      Accept:
+      - "*/*"
+      Date:
+      - Fri, 22 May 2015 12:14:37 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie:
+      - _ZopeId=47495875A68v.lkNK6o
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
+      Date:
+      - Fri, 22 May 2015 12:14:37 GMT
+      Content-Length:
+      - '2198'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "d4f54b53-7544-432b-8e06-d28b6233070b", "action": "DeviceRouter",
+        "result": {"disabled": false, "data": {"productionState": 1000, "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice",
+        "links": "", "snmpContact": "", "osModel": null, "hwModel": null, "osManufacturer":
+        null, "deviceClass": {"uuid": "98db2956-4f5f-42f5-ac1f-173ff47b306d", "name":
+        "/Server", "severity": "error", "id": "Server", "meta_type": "DeviceClass",
+        "inspector_type": "DeviceClass", "path": "/Devices/Server", "uid": "/zport/dmd/Devices/Server",
+        "events": {"info": {"count": 1, "acknowledged_count": 0}, "clear": {"count":
+        0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
+        0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
+        1, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
+        "description": ""}, "hwManufacturer": null, "snmpVersion": "v2c", "collector":
+        "localhost", "id": "UnitTestDevice", "uptime": "Unknown", "severity": "clear",
+        "locking": {"updates": false, "deletion": false, "events": false}, "comments":
+        "", "name": "UnitTestDevice", "priority": 3, "snmpCommunity": "public", "location":
+        null, "memory": {"ram": "Unknown", "swap": "Unknown"}, "icon": "/zport/dmd/img/icons/server.png",
+        "priorityLabel": "Normal", "lastCollected": "Not Modeled", "events": {"info":
+        {"count": 0, "acknowledged_count": 0}, "clear": {"count": 0, "acknowledged_count":
+        0}, "warning": {"count": 0, "acknowledged_count": 0}, "critical": {"count":
+        0, "acknowledged_count": 0}, "error": {"count": 0, "acknowledged_count": 0},
+        "debug": {"count": 0, "acknowledged_count": 0}}, "systems": [], "status":
+        true, "ipAddressString": null, "description": "", "snmpDescr": "", "groups":
+        [], "device": "UnitTestDevice", "firstSeen": "2015/05/22 12:14:21", "snmpSysName":
+        "", "pythonClass": "Products.ZenModel.Device", "lastChanged": "2015/05/22
+        12:14:37", "productionStateLabel": "Production", "serialNumber": "", "uuid":
+        "00217159-594e-49da-889c-7650f8329068", "tagNumber": "", "meta_type": "Device",
+        "inspector_type": "Device", "snmpLocation": "", "snmpAgent": "", "ipAddress":
+        null, "rackSlot": 0}, "success": true}, "tid": 22, "type": "rpc", "method":
+        "getInfo"}'
+    http_version: 
+  recorded_at: Fri, 22 May 2015 12:14:37 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/4_2_5_test_0006_returns_an_Array_of_events_for_all_devices.yml
+++ b/test/fixtures/vcr_cassettes/4_2_5_test_0006_returns_an_Array_of_events_for_all_devices.yml
@@ -2,21 +2,21 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":19}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":6}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:27 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -25,14 +25,14 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:27 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Length:
-      - '906'
+      - '905'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "aa582d6b-47ec-4afb-bcd6-b87b00ea58d0", "action": "DeviceRouter",
+      string: '{"uuid": "1723c17e-f1e8-4a09-b67e-9eb985de6a1a", "action": "DeviceRouter",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
         null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
         null, "collector": "localhost", "osModel": null, "productionState": 1000,
@@ -42,26 +42,26 @@ http_interactions:
         "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
         0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
         0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
-        "name": "UnitTestDevice"}]}, "tid": 19, "type": "rpc", "method": "getDevices"}'
+        "name": "UnitTestDevice"}]}, "tid": 6, "type": "rpc", "method": "getDevices"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:27 GMT
+  recorded_at: Fri, 22 May 2015 12:14:36 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/evconsole_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/evconsole_router
     body:
       encoding: UTF-8
-      string: '[{"action":"EventsRouter","method":"query","data":[{"limit":100,"start":0,"sort":"lastTime","dir":"DESC"}],"type":"rpc","tid":20}]'
+      string: '[{"action":"EventsRouter","method":"query","data":[{"limit":100,"start":0,"sort":"lastTime","dir":"DESC"}],"type":"rpc","tid":7}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:27 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -70,45 +70,115 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:27 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Length:
-      - '4183'
+      - '9943'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "6b20be45-a361-4c31-b470-f9085992ac79", "action": "EventsRouter",
-        "result": {"totalCount": 3, "events": [{"prodState": null, "firstTime": "2015-05-22
-        09:12:02", "facility": null, "eventClassKey": null, "agent": null, "dedupid":
+      string: '{"uuid": "8bcc3aa4-4d75-4945-8deb-7963b5bcba70", "action": "EventsRouter",
+        "result": {"totalCount": 7, "events": [{"prodState": null, "firstTime": "2015-05-22
+        12:13:50", "facility": null, "eventClassKey": null, "agent": null, "dedupid":
         "UnitTestDevice||/Change/Remove|2|Deleted device: UnitTestDevice", "Location":
         [], "ownerid": null, "eventClass": {"text": "/Change/Remove", "uid": "/zport/dmd/Events/Change/Remove"},
-        "id": "0242ac11-001e-9740-11e5-00629bc10069", "DevicePriority": null, "monitor":
+        "id": "0242ac11-0025-9742-11e5-007c0173f789", "DevicePriority": null, "monitor":
         null, "priority": null, "details": {}, "DeviceClass": [], "eventKey": "",
-        "evid": "0242ac11-001e-9740-11e5-00629bc10069", "eventClassMapping": "", "component":
+        "evid": "0242ac11-0025-9742-11e5-007c0173f789", "eventClassMapping": "", "component":
         {"url": null, "text": null, "uid": null, "uuid": null}, "clearid": null, "DeviceGroups":
-        [], "eventGroup": null, "device": {"url": "/zport/dmd/goto?guid=b71deecb-3dbc-471e-90f1-3bf947ec121d",
-        "text": "UnitTestDevice", "uuid": "b71deecb-3dbc-471e-90f1-3bf947ec121d",
+        [], "eventGroup": null, "device": {"url": "/zport/dmd/goto?guid=00217159-594e-49da-889c-7650f8329068",
+        "text": "UnitTestDevice", "uuid": "00217159-594e-49da-889c-7650f8329068",
         "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice"}, "message": "Deleted
         device: UnitTestDevice", "severity": 2, "count": 1, "stateChange": "2015-05-22
-        09:12:02", "ntevid": null, "summary": "Deleted device: UnitTestDevice", "eventState":
-        "Closed", "lastTime": "2015-05-22 09:12:02", "ipAddress": "", "Systems": []},
-        {"prodState": "Production", "firstTime": "2015-05-22 08:59:59", "facility":
+        12:13:50", "ntevid": null, "summary": "Deleted device: UnitTestDevice", "eventState":
+        "Closed", "lastTime": "2015-05-22 12:13:50", "ipAddress": "", "Systems": []},
+        {"prodState": "Production", "firstTime": "2015-05-22 11:52:49", "facility":
         null, "eventClassKey": null, "agent": "zenperfsnmp", "dedupid": "localhost||/Status/Snmp|agent_down|4",
         "Location": [], "ownerid": null, "eventClass": {"text": "/Status/Snmp", "uid":
-        "/zport/dmd/Events/Status/Snmp"}, "id": "0242ac11-001e-9740-11e5-0060ef1c55e5",
+        "/zport/dmd/Events/Status/Snmp"}, "id": "0242ac11-0025-9742-11e5-00791464c7f3",
         "DevicePriority": "Normal", "monitor": "localhost", "priority": null, "details":
-        {"zenoss.device.ip_address": ["::1"], "manager": ["19518d7c730e"], "zenoss.device.production_state":
+        {"zenoss.device.ip_address": ["::1"], "manager": ["88f2dd80f749"], "zenoss.device.production_state":
         ["1000"], "zenoss.device.priority": ["3"], "zenoss.device.device_class": ["/Server/Linux"]},
         "DeviceClass": [{"uid": "/zport/dmd/Devices/Server/Linux", "name": "/Server/Linux"}],
-        "eventKey": "agent_down", "evid": "0242ac11-001e-9740-11e5-0060ef1c55e5",
+        "eventKey": "agent_down", "evid": "0242ac11-0025-9742-11e5-00791464c7f3",
         "eventClassMapping": "", "component": {"url": null, "text": null, "uid": null,
         "uuid": null}, "clearid": null, "DeviceGroups": [], "eventGroup": "SnmpTest",
         "device": {"url": "/zport/dmd/goto?guid=86b9d5f6-59d7-4eec-a2f0-146ef91fe9a9",
         "text": "localhost", "uuid": "86b9d5f6-59d7-4eec-a2f0-146ef91fe9a9", "uid":
         "/zport/dmd/Devices/Server/Linux/devices/localhost"}, "message": "SNMP agent
-        down - no response received", "severity": 4, "count": 3, "stateChange": "2015-05-22
-        08:59:59", "ntevid": null, "summary": "SNMP agent down - no response received",
-        "eventState": "New", "lastTime": "2015-05-22 09:09:59", "ipAddress": ["::1"],
+        down - no response received", "severity": 4, "count": 5, "stateChange": "2015-05-22
+        11:52:49", "ntevid": null, "summary": "SNMP agent down - no response received",
+        "eventState": "New", "lastTime": "2015-05-22 12:12:49", "ipAddress": ["::1"],
+        "Systems": []}, {"prodState": "Production", "firstTime": "2015-05-22 11:52:28",
+        "facility": null, "eventClassKey": null, "agent": "zenpython", "dedupid":
+        "localhost|zenpython|/Status/Heartbeat|0|localhost zenpython heartbeat clear",
+        "Location": [], "ownerid": null, "eventClass": {"text": "/Status/Heartbeat",
+        "uid": "/zport/dmd/Events/Status/Heartbeat"}, "id": "0242ac11-0025-9742-11e5-0079051da5f1",
+        "DevicePriority": "Normal", "monitor": "localhost", "priority": null, "details":
+        {"zenoss.device.ip_address": ["::1"], "zenoss.device.production_state": ["1000"],
+        "zenoss.device.priority": ["3"], "zenoss.device.device_class": ["/Server/Linux"]},
+        "DeviceClass": [{"uid": "/zport/dmd/Devices/Server/Linux", "name": "/Server/Linux"}],
+        "eventKey": null, "evid": "0242ac11-0025-9742-11e5-0079051da5f1", "eventClassMapping":
+        "", "component": {"url": null, "text": "zenpython", "uid": null, "uuid": null},
+        "clearid": null, "DeviceGroups": [], "eventGroup": null, "device": {"url":
+        "/zport/dmd/goto?guid=86b9d5f6-59d7-4eec-a2f0-146ef91fe9a9", "text": "localhost",
+        "uuid": "86b9d5f6-59d7-4eec-a2f0-146ef91fe9a9", "uid": "/zport/dmd/Devices/Server/Linux/devices/localhost"},
+        "message": "localhost zenpython heartbeat clear", "severity": 0, "count":
+        1, "stateChange": "2015-05-22 11:52:28", "ntevid": null, "summary": "localhost
+        zenpython heartbeat clear", "eventState": "Closed", "lastTime": "2015-05-22
+        11:52:28", "ipAddress": ["::1"], "Systems": []}, {"prodState": "Production",
+        "firstTime": "2015-05-22 11:52:28", "facility": null, "eventClassKey": null,
+        "agent": "zenjmx", "dedupid": "localhost|zenjmx|/Status/Heartbeat|0|localhost
+        zenjmx heartbeat clear", "Location": [], "ownerid": null, "eventClass": {"text":
+        "/Status/Heartbeat", "uid": "/zport/dmd/Events/Status/Heartbeat"}, "id": "0242ac11-0025-9742-11e5-0079051da5f2",
+        "DevicePriority": "Normal", "monitor": "localhost", "priority": null, "details":
+        {"zenoss.device.ip_address": ["::1"], "zenoss.device.production_state": ["1000"],
+        "zenoss.device.priority": ["3"], "zenoss.device.device_class": ["/Server/Linux"]},
+        "DeviceClass": [{"uid": "/zport/dmd/Devices/Server/Linux", "name": "/Server/Linux"}],
+        "eventKey": null, "evid": "0242ac11-0025-9742-11e5-0079051da5f2", "eventClassMapping":
+        "", "component": {"url": null, "text": "zenjmx", "uid": null, "uuid": null},
+        "clearid": null, "DeviceGroups": [], "eventGroup": null, "device": {"url":
+        "/zport/dmd/goto?guid=86b9d5f6-59d7-4eec-a2f0-146ef91fe9a9", "text": "localhost",
+        "uuid": "86b9d5f6-59d7-4eec-a2f0-146ef91fe9a9", "uid": "/zport/dmd/Devices/Server/Linux/devices/localhost"},
+        "message": "localhost zenjmx heartbeat clear", "severity": 0, "count": 1,
+        "stateChange": "2015-05-22 11:52:28", "ntevid": null, "summary": "localhost
+        zenjmx heartbeat clear", "eventState": "Closed", "lastTime": "2015-05-22 11:52:28",
+        "ipAddress": ["::1"], "Systems": []}, {"prodState": "Production", "firstTime":
+        "2015-05-22 11:51:28", "facility": null, "eventClassKey": null, "agent": "zenpython",
+        "dedupid": "localhost|zenpython|/Status/Heartbeat|4|localhost zenpython heartbeat
+        failure", "Location": [], "ownerid": null, "eventClass": {"text": "/Status/Heartbeat",
+        "uid": "/zport/dmd/Events/Status/Heartbeat"}, "id": "0242ac11-0025-9742-11e5-0078e1cf68dd",
+        "DevicePriority": "Normal", "monitor": "localhost", "priority": null, "details":
+        {"zenoss.device.ip_address": ["::1"], "zenoss.device.production_state": ["1000"],
+        "zenoss.device.priority": ["3"], "zenoss.device.device_class": ["/Server/Linux"]},
+        "DeviceClass": [{"uid": "/zport/dmd/Devices/Server/Linux", "name": "/Server/Linux"}],
+        "eventKey": null, "evid": "0242ac11-0025-9742-11e5-0078e1cf68dd", "eventClassMapping":
+        "", "component": {"url": null, "text": "zenpython", "uid": null, "uuid": null},
+        "clearid": "0242ac11-0025-9742-11e5-0079051da5f1", "DeviceGroups": [], "eventGroup":
+        null, "device": {"url": "/zport/dmd/goto?guid=86b9d5f6-59d7-4eec-a2f0-146ef91fe9a9",
+        "text": "localhost", "uuid": "86b9d5f6-59d7-4eec-a2f0-146ef91fe9a9", "uid":
+        "/zport/dmd/Devices/Server/Linux/devices/localhost"}, "message": "localhost
+        zenpython heartbeat failure", "severity": 4, "count": 1, "stateChange": "2015-05-22
+        11:52:28", "ntevid": null, "summary": "localhost zenpython heartbeat failure",
+        "eventState": "Cleared", "lastTime": "2015-05-22 11:51:28", "ipAddress": ["::1"],
+        "Systems": []}, {"prodState": "Production", "firstTime": "2015-05-22 11:51:28",
+        "facility": null, "eventClassKey": null, "agent": "zenjmx", "dedupid": "localhost|zenjmx|/Status/Heartbeat|4|localhost
+        zenjmx heartbeat failure", "Location": [], "ownerid": null, "eventClass":
+        {"text": "/Status/Heartbeat", "uid": "/zport/dmd/Events/Status/Heartbeat"},
+        "id": "0242ac11-0025-9742-11e5-0078e1e6c16e", "DevicePriority": "Normal",
+        "monitor": "localhost", "priority": null, "details": {"zenoss.device.ip_address":
+        ["::1"], "zenoss.device.production_state": ["1000"], "zenoss.device.priority":
+        ["3"], "zenoss.device.device_class": ["/Server/Linux"]}, "DeviceClass": [{"uid":
+        "/zport/dmd/Devices/Server/Linux", "name": "/Server/Linux"}], "eventKey":
+        null, "evid": "0242ac11-0025-9742-11e5-0078e1e6c16e", "eventClassMapping":
+        "", "component": {"url": null, "text": "zenjmx", "uid": null, "uuid": null},
+        "clearid": "0242ac11-0025-9742-11e5-0079051da5f2", "DeviceGroups": [], "eventGroup":
+        null, "device": {"url": "/zport/dmd/goto?guid=86b9d5f6-59d7-4eec-a2f0-146ef91fe9a9",
+        "text": "localhost", "uuid": "86b9d5f6-59d7-4eec-a2f0-146ef91fe9a9", "uid":
+        "/zport/dmd/Devices/Server/Linux/devices/localhost"}, "message": "localhost
+        zenjmx heartbeat failure", "severity": 4, "count": 1, "stateChange": "2015-05-22
+        11:52:28", "ntevid": null, "summary": "localhost zenjmx heartbeat failure",
+        "eventState": "Cleared", "lastTime": "2015-05-22 11:51:28", "ipAddress": ["::1"],
         "Systems": []}, {"prodState": "Production", "firstTime": "2015-05-22 08:51:29",
         "facility": null, "eventClassKey": null, "agent": "zendisc", "dedupid": "localhost|::1|/Status/Snmp|::1|2",
         "Location": [], "ownerid": null, "eventClass": {"text": "/Status/Snmp", "uid":
@@ -126,8 +196,8 @@ http_interactions:
         2, "count": 1, "stateChange": "2015-05-22 08:51:29", "ntevid": null, "summary":
         "''Discovered device name ''localhost'' for ip ''::1''", "eventState": "New",
         "lastTime": "2015-05-22 08:51:29", "ipAddress": ["::1"], "Systems": []}],
-        "success": true, "asof": 1432285947.499528}, "tid": 20, "type": "rpc", "method":
+        "success": true, "asof": 1432296876.43313}, "tid": 7, "type": "rpc", "method":
         "query"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:27 GMT
+  recorded_at: Fri, 22 May 2015 12:14:36 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/4_2_5_test_0007_fetches_the_report_tree.yml
+++ b/test/fixtures/vcr_cassettes/4_2_5_test_0007_fetches_the_report_tree.yml
@@ -2,21 +2,21 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":21}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":4}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:27 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -25,14 +25,14 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:27 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Length:
-      - '906'
+      - '905'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "3dbb789e-229d-4092-a4e4-c0b33392328f", "action": "DeviceRouter",
+      string: '{"uuid": "91981720-a275-4d8c-b15e-53282e13430d", "action": "DeviceRouter",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
         null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
         null, "collector": "localhost", "osModel": null, "productionState": 1000,
@@ -42,26 +42,26 @@ http_interactions:
         "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
         0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
         0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
-        "name": "UnitTestDevice"}]}, "tid": 21, "type": "rpc", "method": "getDevices"}'
+        "name": "UnitTestDevice"}]}, "tid": 4, "type": "rpc", "method": "getDevices"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:27 GMT
+  recorded_at: Fri, 22 May 2015 12:14:36 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/report_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/report_router
     body:
       encoding: UTF-8
-      string: '[{"action":"ReportRouter","method":"getTree","data":[{"id":"/zport/dmd/Reports"}],"type":"rpc","tid":22}]'
+      string: '[{"action":"ReportRouter","method":"getTree","data":[{"id":"/zport/dmd/Reports"}],"type":"rpc","tid":5}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:27 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -70,14 +70,14 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:27 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Length:
-      - '9701'
+      - '9700'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "2dbedd39-537a-4dec-ada1-80ba351defbe", "action": "ReportRouter",
+      string: '{"uuid": "6c51a316-3cec-4631-a6bf-e42e4ee015d1", "action": "ReportRouter",
         "result": [{"qtip": "", "hidden": false, "leaf": false, "uid": "/zport/dmd/Reports",
         "text": {"count": 19, "text": "Reports", "description": "reports"}, "id":
         ".zport.dmd.Reports", "meta_type": "ReportClass", "deletable": false, "path":
@@ -197,7 +197,7 @@ http_interactions:
         true, "path": "Reports/Event Reports/All EventMappings", "iconCls": "leaf",
         "id": ".zport.dmd.Reports.Event Reports.All EventMappings", "edit_url": null,
         "uuid": null}], "edit_url": null, "uuid": null}], "edit_url": null, "uuid":
-        null}], "tid": 22, "type": "rpc", "method": "getTree"}'
+        null}], "tid": 5, "type": "rpc", "method": "getTree"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:27 GMT
+  recorded_at: Fri, 22 May 2015 12:14:36 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/4_2_5_test_0008_fetches_available_report_types_and_returns_a_Hash.yml
+++ b/test/fixtures/vcr_cassettes/4_2_5_test_0008_fetches_available_report_types_and_returns_a_Hash.yml
@@ -2,21 +2,21 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":6}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":8}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -25,14 +25,14 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Length:
       - '905'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "608b9f19-1ea0-48af-b479-35cd28d124e6", "action": "DeviceRouter",
+      string: '{"uuid": "f95969e7-1bcc-4fba-8ae0-c233c66323ee", "action": "DeviceRouter",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
         null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
         null, "collector": "localhost", "osModel": null, "productionState": 1000,
@@ -42,26 +42,26 @@ http_interactions:
         "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
         0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
         0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
-        "name": "UnitTestDevice"}]}, "tid": 6, "type": "rpc", "method": "getDevices"}'
+        "name": "UnitTestDevice"}]}, "tid": 8, "type": "rpc", "method": "getDevices"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:26 GMT
+  recorded_at: Fri, 22 May 2015 12:14:36 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/report_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/report_router
     body:
       encoding: UTF-8
-      string: '[{"action":"ReportRouter","method":"getReportTypes","data":{},"type":"rpc","tid":7}]'
+      string: '[{"action":"ReportRouter","method":"getReportTypes","data":{},"type":"rpc","tid":9}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -70,17 +70,17 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:26 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Length:
       - '306'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "24171f54-fce5-4e6d-be82-e2e5a1bbd551", "action": "ReportRouter",
+      string: '{"uuid": "b1a42eb7-2f33-46a3-99f2-eed9774e1ca2", "action": "ReportRouter",
         "result": {"menuText": ["Custom Device Report", "Graph Report", "Multi-Graph
         Report"], "reportTypes": ["customDeviceReport", "graphReport", "multiGraphReport"],
-        "success": true}, "tid": 7, "type": "rpc", "method": "getReportTypes"}'
+        "success": true}, "tid": 9, "type": "rpc", "method": "getReportTypes"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:26 GMT
+  recorded_at: Fri, 22 May 2015 12:14:36 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/4_2_5_test_0009_renames_the_device.yml
+++ b/test/fixtures/vcr_cassettes/4_2_5_test_0009_renames_the_device.yml
@@ -2,21 +2,21 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":17}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":13}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:27 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -25,14 +25,14 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:27 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Length:
       - '906'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "5f077581-610f-4993-bd2a-6038bc553036", "action": "DeviceRouter",
+      string: '{"uuid": "97f48fcd-7b09-43c1-94f0-d2ec4e3dd7c8", "action": "DeviceRouter",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
         null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
         null, "collector": "localhost", "osModel": null, "productionState": 1000,
@@ -42,12 +42,12 @@ http_interactions:
         "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
         0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
         0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
-        "name": "UnitTestDevice"}]}, "tid": 17, "type": "rpc", "method": "getDevices"}'
+        "name": "UnitTestDevice"}]}, "tid": 13, "type": "rpc", "method": "getDevices"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:27 GMT
+  recorded_at: Fri, 22 May 2015 12:14:36 GMT
 - request:
     method: get
-    uri: http://localhost:8080/zport/dmd/zport/dmd/Devices/Server/devices/UnitTestDevice/renameDevice?newId=unit_test_temporary_device_name
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/Devices/Server/devices/UnitTestDevice/renameDevice?newId=unit_test_temporary_device_name
     body:
       encoding: UTF-8
       string: ''
@@ -57,9 +57,9 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:27 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -68,7 +68,7 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:27 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Length:
       - '65'
       Content-Type:
@@ -77,24 +77,24 @@ http_interactions:
       encoding: UTF-8
       string: "/zport/dmd/Devices/Server/devices/unit_test_temporary_device_name"
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:27 GMT
+  recorded_at: Fri, 22 May 2015 12:14:37 GMT
 - request:
     method: post
-    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/device_router
     body:
       encoding: UTF-8
-      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"unit_test_temporary_device_name"}}],"type":"rpc","tid":18}]'
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"unit_test_temporary_device_name"}}],"type":"rpc","tid":14}]'
     headers:
       User-Agent:
       - HTTPClient/1.0 (2.6.0.1, ruby 2.2.0 (2014-12-25))
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:27 GMT
+      - Fri, 22 May 2015 12:14:37 GMT
       Content-Type:
       - application/json; charset=utf-8
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -103,14 +103,14 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:27 GMT
+      - Fri, 22 May 2015 12:14:36 GMT
       Content-Length:
       - '940'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"uuid": "ee9bf06e-921b-4b0a-8c82-761cd50f8a02", "action": "DeviceRouter",
+      string: '{"uuid": "ba140e8f-1063-46c9-95d7-0a8e5cbff659", "action": "DeviceRouter",
         "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
         null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
         null, "collector": "localhost", "osModel": null, "productionState": 1000,
@@ -120,13 +120,13 @@ http_interactions:
         "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
         0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
         0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
-        "name": "unit_test_temporary_device_name"}]}, "tid": 18, "type": "rpc", "method":
+        "name": "unit_test_temporary_device_name"}]}, "tid": 14, "type": "rpc", "method":
         "getDevices"}'
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:27 GMT
+  recorded_at: Fri, 22 May 2015 12:14:37 GMT
 - request:
     method: get
-    uri: http://localhost:8080/zport/dmd/zport/dmd/Devices/Server/devices/unit_test_temporary_device_name/renameDevice?newId=UnitTestDevice
+    uri: http://192.168.56.2:8080/zport/dmd/zport/dmd/Devices/Server/devices/unit_test_temporary_device_name/renameDevice?newId=UnitTestDevice
     body:
       encoding: UTF-8
       string: ''
@@ -136,9 +136,9 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Fri, 22 May 2015 09:12:27 GMT
+      - Fri, 22 May 2015 12:14:37 GMT
       Cookie:
-      - _ZopeId=53572535A68vSC9XJhE
+      - _ZopeId=47495875A68v.lkNK6o
   response:
     status:
       code: 200
@@ -147,7 +147,7 @@ http_interactions:
       Server:
       - Zope/(2.13.13, python 2.7.2, linux2) ZServer/1.1
       Date:
-      - Fri, 22 May 2015 09:12:27 GMT
+      - Fri, 22 May 2015 12:14:37 GMT
       Content-Length:
       - '48'
       Content-Type:
@@ -156,5 +156,5 @@ http_interactions:
       encoding: UTF-8
       string: "/zport/dmd/Devices/Server/devices/UnitTestDevice"
     http_version: 
-  recorded_at: Fri, 22 May 2015 09:12:27 GMT
+  recorded_at: Fri, 22 May 2015 12:14:37 GMT
 recorded_with: VCR 2.9.3

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,11 +12,9 @@ TEST_DEVICE_NAME = "UnitTestDevice"
 
 ZENOSS_VERSION = ENV['zenoss_version'] || '4.2.5'
 
+
 # VCR
 VCR.configure do |config|
   config.cassette_library_dir = "test/fixtures/vcr_cassettes"
   config.hook_into :webmock
-  config.before_record do |rec|
-    rec.request.uri.sub!(ZENOSS_URL, 'http://localhost:8080/zport/dmd')
-  end
 end


### PR DESCRIPTION
The `MiniTest::Runnable#name` is not available on rubies <2.0 causing [tests to fail](https://travis-ci.org/skrobul/zenoss_client/jobs/63626019), so we have to
fall back to `__name__ ` or `__NAME__` method. 

While this solve the problem with naming of the cassette, it [still fails miserably in Travis](https://travis-ci.org/skrobul/zenoss_client/jobs/63632832) but works very well [on my computer](https://gist.github.com/skrobul/c1bb54d0475ccf8ebdc1) with exactly the same settings.
It also works well on all non-19x rubies on Travis... any ideas?