### PR TITLE
Parse times for different versions of Zenoss

### DIFF
--- a/lib/zenoss/events/event.rb
+++ b/lib/zenoss/events/event.rb
@@ -36,9 +36,7 @@ module Zenoss
       # @return[Time, nil] self.firstTime
       def first_time?
         if self.firstTime && self.firstTime != false
-          return self.firstTime
-        else
-          self.firstTime = nil
+          self.firstTime
         end
       end
 
@@ -46,9 +44,7 @@ module Zenoss
       # @return[Time, nil] self.lastTime
       def last_time?
         if self.lastTime && self.lastTime != false
-          return self.lastTime
-        else
-          self.lastTime = nil
+          self.lastTime
         end
       end
 

--- a/lib/zenoss/events/event.rb
+++ b/lib/zenoss/events/event.rb
@@ -32,21 +32,57 @@ module Zenoss
         parse_time_format
       end
 
-      # Parse time format from zenoss
-      # Zenoss version 4 expects the time format to be a string
-      # Zenoss version 6 expects the time to be a float
-      # @return[Time] self.firstTime, self.lastTime the time from zenoss
-      def parse_time_format
+      # Check to see if firstTime is set and not set to false
+      # @return[Time, nil] self.firstTime
+      def first_time?
+        if self.firstTime && self.firstTime != false
+          return self.firstTime
+        else
+          self.firstTime = nil
+        end
+      end
+
+      # Check to see if lastTime is set and not set to false
+      # @return[Time, nil] self.lastTime
+      def last_time?
+        if self.lastTime && self.lastTime != false
+          return self.lastTime
+        else
+          self.lastTime = nil
+        end
+      end
+
+      # Parses the firstTime value
+      # @return[Time] self.firstTime
+      def parse_first_time
         if self.firstTime.is_a?(String)
           self.firstTime = Time.parse(self.firstTime)
         else
           self.firstTime = Time.at(self.firstTime)
         end
+      end
 
+      # Parses the lastTime value
+      # @return[Time] self.lastTime
+      def parse_last_time
         if self.lastTime.is_a?(String)
           self.lastTime = Time.parse(self.lastTime)
         else
           self.lastTime = Time.at(self.lastTime)
+        end
+      end
+
+      # Parse time format from zenoss
+      # Zenoss version 4 emits the time format to be a string
+      # Zenoss version 6 emits the time to be a float
+      # @return[Time] self.firstTime, self.lastTime the time from zenoss
+      def parse_time_format
+        if first_time?
+          parse_first_time
+        end
+
+        if last_time?
+          parse_last_time
         end
       end
 

--- a/lib/zenoss/events/event.rb
+++ b/lib/zenoss/events/event.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 #############################################################################
 # Copyright © 2010 Dan Wanek <dwanek@nd.gov>
 #
@@ -26,18 +25,16 @@ module Zenoss
       # Initialize this object from a Hash returned via the JSON api
       # @param[Zenoss] zenoss the current instance we are connecting with
       # @param[Hash] zhash a hash of values used to create this Event instance
-      # @return[Time] self.firstTime, self.lastTime
       def initialize(zenoss,zhash)
         @zenoss = zenoss
         super zhash
-        #parse_time_format
         self.firstTime &&= convert_time(self.firstTime)
         self.lastTime &&= convert_time(self.lastTime)
       end
 
       # Converts a string or float to a Time object
-      # Zenoss version 4 emits the time format to be a string
-      # Zenoss version 6 emits the time to be a float
+      # Zenoss version 4 emits the time format as a string
+      # Zenoss version 6 emits the time as a float
       # @return[Time]
       def convert_time(time)
         if time.is_a?(String)

--- a/lib/zenoss/events/event.rb
+++ b/lib/zenoss/events/event.rb
@@ -48,37 +48,27 @@ module Zenoss
         end
       end
 
-      # Parses the firstTime value
-      # @return[Time] self.firstTime
-      def parse_first_time
-        if self.firstTime.is_a?(String)
-          self.firstTime = Time.parse(self.firstTime)
+      # Converts a string or float to a Time object
+      # Zenoss version 4 emits the time format to be a string
+      # Zenoss version 6 emits the time to be a float
+      # @return[Time]
+      def convert_time(time)
+        if time.is_a?(String)
+          Time.parse(time)
         else
-          self.firstTime = Time.at(self.firstTime)
-        end
-      end
-
-      # Parses the lastTime value
-      # @return[Time] self.lastTime
-      def parse_last_time
-        if self.lastTime.is_a?(String)
-          self.lastTime = Time.parse(self.lastTime)
-        else
-          self.lastTime = Time.at(self.lastTime)
+          Time.at(time)
         end
       end
 
       # Parse time format from zenoss
-      # Zenoss version 4 emits the time format to be a string
-      # Zenoss version 6 emits the time to be a float
       # @return[Time] self.firstTime, self.lastTime the time from zenoss
       def parse_time_format
         if first_time
-          parse_first_time
+          self.firstTime = convert_time(self.firstTime)
         end
 
         if last_time
-          parse_last_time
+          self.lastTime = convert_time(self.lastTime)
         end
       end
 

--- a/lib/zenoss/events/event.rb
+++ b/lib/zenoss/events/event.rb
@@ -34,7 +34,7 @@ module Zenoss
 
       # Check to see if firstTime is set and not set to false
       # @return[Time, nil] self.firstTime
-      def first_time?
+      def first_time
         if self.firstTime && self.firstTime != false
           self.firstTime
         end
@@ -42,7 +42,7 @@ module Zenoss
 
       # Check to see if lastTime is set and not set to false
       # @return[Time, nil] self.lastTime
-      def last_time?
+      def last_time
         if self.lastTime && self.lastTime != false
           self.lastTime
         end
@@ -73,11 +73,11 @@ module Zenoss
       # Zenoss version 6 emits the time to be a float
       # @return[Time] self.firstTime, self.lastTime the time from zenoss
       def parse_time_format
-        if first_time?
+        if first_time
           parse_first_time
         end
 
-        if last_time?
+        if last_time
           parse_last_time
         end
       end

--- a/lib/zenoss/events/event.rb
+++ b/lib/zenoss/events/event.rb
@@ -35,18 +35,18 @@ module Zenoss
       # Parse time format from zenoss
       # Zenoss version 4 expects the time format to be a string
       # Zenoss version 6 expects the time to be a float
-      # @return[DateTime, String] self.firstTime, self.lastTime the time from zenoss
+      # @return[Time] self.firstTime, self.lastTime the time from zenoss
       def parse_time_format
         if self.firstTime.is_a?(String)
-          self.firstTime = DateTime.parse(self.firstTime)
+          self.firstTime = Time.parse(self.firstTime)
         else
-          self.firstTime = Time.at(self.firstTime).to_datetime.to_s
+          self.firstTime = Time.at(self.firstTime)
         end
 
         if self.lastTime.is_a?(String)
-          self.lastTime = DateTime.parse(self.lastTime)
+          self.lastTime = Time.parse(self.lastTime)
         else
-          self.lastTime = Time.at(self.lastTime).to_datetime.to_s
+          self.lastTime = Time.at(self.lastTime)
         end
       end
 

--- a/lib/zenoss/events/event.rb
+++ b/lib/zenoss/events/event.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 #############################################################################
 # Copyright © 2010 Dan Wanek <dwanek@nd.gov>
 #
@@ -28,8 +29,25 @@ module Zenoss
       def initialize(zenoss,zhash)
         @zenoss = zenoss
         super zhash
-        self.firstTime = DateTime.parse(self.firstTime) if self.firstTime
-        self.lastTime  = DateTime.parse(self.lastTime) if self.lastTime
+        parse_time_format
+      end
+
+      # Parse time format from zenoss
+      # Zenoss version 4 expects the time format to be a string
+      # Zenoss version 6 expects the time to be a float
+      # @return[DateTime, String] self.firstTime, self.lastTime the time from zenoss
+      def parse_time_format
+        if self.firstTime.is_a?(String)
+          self.firstTime = DateTime.parse(self.firstTime)
+        else
+          self.firstTime = Time.at(self.firstTime).to_datetime.to_s
+        end
+
+        if self.lastTime.is_a?(String)
+          self.lastTime = DateTime.parse(self.lastTime)
+        else
+          self.lastTime = Time.at(self.lastTime).to_datetime.to_s
+        end
       end
 
       def detail(history = false)

--- a/lib/zenoss/events/event.rb
+++ b/lib/zenoss/events/event.rb
@@ -26,26 +26,13 @@ module Zenoss
       # Initialize this object from a Hash returned via the JSON api
       # @param[Zenoss] zenoss the current instance we are connecting with
       # @param[Hash] zhash a hash of values used to create this Event instance
+      # @return[Time] self.firstTime, self.lastTime
       def initialize(zenoss,zhash)
         @zenoss = zenoss
         super zhash
-        parse_time_format
-      end
-
-      # Check to see if firstTime is set and not set to false
-      # @return[Time, nil] self.firstTime
-      def first_time
-        if self.firstTime && self.firstTime != false
-          self.firstTime
-        end
-      end
-
-      # Check to see if lastTime is set and not set to false
-      # @return[Time, nil] self.lastTime
-      def last_time
-        if self.lastTime && self.lastTime != false
-          self.lastTime
-        end
+        #parse_time_format
+        self.firstTime &&= convert_time(self.firstTime)
+        self.lastTime &&= convert_time(self.lastTime)
       end
 
       # Converts a string or float to a Time object
@@ -57,18 +44,6 @@ module Zenoss
           Time.parse(time)
         else
           Time.at(time)
-        end
-      end
-
-      # Parse time format from zenoss
-      # @return[Time] self.firstTime, self.lastTime the time from zenoss
-      def parse_time_format
-        if first_time
-          self.firstTime = convert_time(self.firstTime)
-        end
-
-        if last_time
-          self.lastTime = convert_time(self.lastTime)
         end
       end
 

--- a/test/zenoss_client_test.rb
+++ b/test/zenoss_client_test.rb
@@ -145,18 +145,18 @@ describe Zenoss::Events::Event do
     lastTime = Time.new(2018, 10, 3, 3, 0, 0).to_s
     event = Zenoss::Events::Event.new(@zenoss, firstTime: firstTime, lastTime: lastTime)
     event.must_be_kind_of Zenoss::Events::Event
-    event.firstTime.must_be_kind_of DateTime
-    event.lastTime.must_be_kind_of DateTime
+    event.firstTime.must_be_kind_of Time
+    event.lastTime.must_be_kind_of Time
   end
 
   it 'intializes an object with times as unix time' do
     @zenoss = Zenoss
-    firstTime = Time.now.to_f
-    lastTime = Time.now.to_f
+    firstTime = Time.new(2018, 10, 3, 2, 0, 0).to_f
+    lastTime = Time.new(2018, 10, 3, 5, 0, 0).to_f
     event = Zenoss::Events::Event.new(@zenoss, firstTime: firstTime, lastTime: lastTime)
     event.must_be_kind_of Zenoss::Events::Event
-    event.firstTime.class.must_equal String
-    event.firstTime.must_be_kind_of String
-    event.lastTime.must_be_kind_of String
+    event.firstTime.class.must_equal Time
+    event.firstTime.must_be_kind_of Time
+    event.lastTime.must_be_kind_of Time
   end
 end

--- a/test/zenoss_client_test.rb
+++ b/test/zenoss_client_test.rb
@@ -188,7 +188,7 @@ describe Zenoss::Events::Event do
     }
     event = Zenoss::Events::Event.new(@zenoss, zhash)
     event.must_be_kind_of Zenoss::Events::Event
-    assert_nil event.firstTime
-    assert_nil event.lastTime
+    event.firstTime.must_equal false
+    event.lastTime.must_equal false
   end
 end

--- a/test/zenoss_client_test.rb
+++ b/test/zenoss_client_test.rb
@@ -137,3 +137,26 @@ describe Zenoss do
     end
   end
 end
+
+describe Zenoss::Events::Event do
+  it 'initializes an object with times as strings' do
+    @zenoss = Zenoss
+    firstTime = Time.new(2018, 10, 3, 1, 0, 0).to_s
+    lastTime = Time.new(2018, 10, 3, 3, 0, 0).to_s
+    event = Zenoss::Events::Event.new(@zenoss, firstTime: firstTime, lastTime: lastTime)
+    event.must_be_kind_of Zenoss::Events::Event
+    event.firstTime.must_be_kind_of DateTime
+    event.lastTime.must_be_kind_of DateTime
+  end
+
+  it 'intializes an object with times as unix time' do
+    @zenoss = Zenoss
+    firstTime = Time.now.to_f
+    lastTime = Time.now.to_f
+    event = Zenoss::Events::Event.new(@zenoss, firstTime: firstTime, lastTime: lastTime)
+    event.must_be_kind_of Zenoss::Events::Event
+    event.firstTime.class.must_equal String
+    event.firstTime.must_be_kind_of String
+    event.lastTime.must_be_kind_of String
+  end
+end

--- a/test/zenoss_client_test.rb
+++ b/test/zenoss_client_test.rb
@@ -141,9 +141,13 @@ end
 describe Zenoss::Events::Event do
   it 'initializes an object with times as strings' do
     @zenoss = Zenoss
-    firstTime = Time.new(2018, 10, 3, 1, 0, 0).to_s
-    lastTime = Time.new(2018, 10, 3, 3, 0, 0).to_s
-    event = Zenoss::Events::Event.new(@zenoss, firstTime: firstTime, lastTime: lastTime)
+    firstTime = Time.new(2018, 10, 3, 1, 0, 0)
+    lastTime = Time.new(2018, 10, 3, 3, 0, 0)
+    zhash = {
+      firstTime: firstTime.to_s,
+      lastTime: lastTime.to_s
+    }
+    event = Zenoss::Events::Event.new(@zenoss, zhash)
     event.must_be_kind_of Zenoss::Events::Event
     event.firstTime.must_be_kind_of Time
     event.lastTime.must_be_kind_of Time
@@ -151,12 +155,40 @@ describe Zenoss::Events::Event do
 
   it 'intializes an object with times as unix time' do
     @zenoss = Zenoss
-    firstTime = Time.new(2018, 10, 3, 2, 0, 0).to_f
-    lastTime = Time.new(2018, 10, 3, 5, 0, 0).to_f
-    event = Zenoss::Events::Event.new(@zenoss, firstTime: firstTime, lastTime: lastTime)
+    firstTime = Time.new(2018, 10, 3, 2, 0, 0)
+    lastTime = Time.new(2018, 10, 3, 5, 0, 0)
+    zhash = {
+      firstTime: firstTime.to_f,
+      lastTime: lastTime.to_f
+    }
+    event = Zenoss::Events::Event.new(@zenoss, zhash)
     event.must_be_kind_of Zenoss::Events::Event
     event.firstTime.class.must_equal Time
     event.firstTime.must_be_kind_of Time
     event.lastTime.must_be_kind_of Time
+  end
+
+  it 'intializes an object with times set to nil' do
+    @zenoss = Zenoss
+    zhash = {
+      firstTime: nil,
+      lastTime: nil
+    }
+    event = Zenoss::Events::Event.new(@zenoss, zhash)
+    event.must_be_kind_of Zenoss::Events::Event
+    assert_nil event.firstTime
+    assert_nil event.lastTime
+  end
+
+  it 'intializes an object with times set to false' do
+    @zenoss = Zenoss
+    zhash = {
+      firstTime: false,
+      lastTime: false
+    }
+    event = Zenoss::Events::Event.new(@zenoss, zhash)
+    event.must_be_kind_of Zenoss::Events::Event
+    assert_nil event.firstTime
+    assert_nil event.lastTime
   end
 end


### PR DESCRIPTION
The different versions of zenoss report the time in different formats, so this accounts for those differences.