### PR TITLE
Updates for Zenoss API Version 6.2.1 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ rvm:
   - jruby-head
 
 install:
-  - gem install bundler
+  - gem install bundler -v 1.17.3
   - bundle install --jobs=3 --retry=3

--- a/lib/zenoss/connection.rb
+++ b/lib/zenoss/connection.rb
@@ -32,6 +32,7 @@ module Zenoss
     include Zenoss::RESTAPI
 
     def initialize(url, user, pass, opts = {}, &block)
+      @zenoss_version = opts[:version]
       @zenoss_uri = (url.is_a?(URI) ? url : URI.parse(url))
       @request_number = 1
       @httpcli = HTTPClient.new

--- a/lib/zenoss/jsonapi/report_router.rb
+++ b/lib/zenoss/jsonapi/report_router.rb
@@ -26,7 +26,11 @@ module Zenoss
       end
 
       def get_report_tree(id = '/zport/dmd/Reports')
-        json_request('ReportRouter', 'getTree', [{:id => id}])
+        if @zenoss_version && @zenoss_version > '6'
+          json_request('ReportRouter', 'asyncGetTree', [id])
+        else
+          json_request('ReportRouter', 'getTree', [{:id => id}])
+        end
       end
 
     end # ReportRouter

--- a/test/fixtures/vcr_cassettes/6_2_1_initial_connection.yml
+++ b/test/fixtures/vcr_cassettes/6_2_1_initial_connection.yml
@@ -1,0 +1,188 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/acl_users/cookieAuthHelper/login
+    body:
+      encoding: UTF-8
+      string: __ac_name=admin&__ac_password=zenoss&submitted=true&came_from=https%3A%2F%2Fhttp:://localhost:8080/zport/dmd%2Fzport%2Fdmd
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:46 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie: ''
+  response:
+    status:
+      code: 302
+      message: Found
+    headers:
+      Content-Length:
+      - '25'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 19 Feb 2019 22:36:47 GMT
+      Location:
+      - "/zport/dmd?submitted=true"
+      Server: ''
+      Set-Cookie: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: "/zport/dmd?submitted=true"
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:47 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd//zport/dmd?submitted=true
+    body:
+      encoding: UTF-8
+      string: __ac_name=admin&__ac_password=zenoss&submitted=true&came_from=https%3A%2F%2Fhttp:://localhost:8080/zport/dmd%2Fzport%2Fdmd
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:47 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Tue, 19 Feb 2019 22:36:47 GMT
+      Server: ''
+      Set-Cookie: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Page-Speed:
+      - 1.11.33.4-0
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: "\\n\\n    <!DOCTYPE html>\\n<html>\\n"
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:48 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    body:
+      encoding: UTF-8
+      string: __ac_name=admin&__ac_password=zenoss&submitted=true&came_from=https%3A%2F%2Fhttp:://localhost:8080/zport/dmd%2Fzport%2Fdmd
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:48 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:49 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '309'
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "02f12150-4aa5-4616-a35d-fd4b942421a4", "action": "DeviceRouter",
+        "result": {"new_jobs": [{"uuid": "3bbee1ec-4f40-44ce-ada1-cc064eb40505", "description":
+        "Create UnitTestDevice under /Devices/Server", "uid": "/zport/dmd/JobManager"}],
+        "success": true}, "tid": 1, "type": "rpc", "method": "addDevice"}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:49 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    body:
+      encoding: UTF-8
+      string: __ac_name=admin&__ac_password=zenoss&submitted=true&came_from=https%3A%2F%2Fhttp:://localhost:8080/zport/dmd%2Fzport%2Fdmd
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:49 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:49 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '904'
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "8c081232-47f0-43f1-9e06-691574b5a164", "action": "DeviceRouter",
+        "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
+        null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
+        null, "collector": "localhost", "osModel": null, "productionState": 400, "systems":
+        [], "priority": 3, "hwModel": null, "tagNumber": "", "osManufacturer": null,
+        "location": null, "groups": [], "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice",
+        "ipAddress": null, "events": {"info": {"count": 0, "acknowledged_count": 0},
+        "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
+        0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
+        0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
+        "name": "UnitTestDevice"}]}, "tid": 2, "type": "rpc", "method": "getDevices"}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:49 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/6_2_1_test_0001_returns_an_Array_of_devices_when_searched_by_name.yml
+++ b/test/fixtures/vcr_cassettes/6_2_1_test_0001_returns_an_Array_of_devices_when_searched_by_name.yml
@@ -1,0 +1,107 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    body:
+      encoding: UTF-8
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":7}]'
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:50 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:50 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '904'
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "99425e21-1fb5-4a6c-8466-b1969bf927ec", "action": "DeviceRouter",
+        "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
+        null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
+        null, "collector": "localhost", "osModel": null, "productionState": 400, "systems":
+        [], "priority": 3, "hwModel": null, "tagNumber": "", "osManufacturer": null,
+        "location": null, "groups": [], "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice",
+        "ipAddress": null, "events": {"info": {"count": 0, "acknowledged_count": 0},
+        "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
+        0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
+        0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
+        "name": "UnitTestDevice"}]}, "tid": 7, "type": "rpc", "method": "getDevices"}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:50 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    body:
+      encoding: UTF-8
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":8}]'
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:50 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:51 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '904'
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "b7f6ae66-d850-4deb-96e3-eb70954e4c4e", "action": "DeviceRouter",
+        "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
+        null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
+        null, "collector": "localhost", "osModel": null, "productionState": 400, "systems":
+        [], "priority": 3, "hwModel": null, "tagNumber": "", "osManufacturer": null,
+        "location": null, "groups": [], "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice",
+        "ipAddress": null, "events": {"info": {"count": 0, "acknowledged_count": 0},
+        "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
+        0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
+        0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
+        "name": "UnitTestDevice"}]}, "tid": 8, "type": "rpc", "method": "getDevices"}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:51 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/6_2_1_test_0002_returns_device_uptime_when_asked.yml
+++ b/test/fixtures/vcr_cassettes/6_2_1_test_0002_returns_device_uptime_when_asked.yml
@@ -1,0 +1,131 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    body:
+      encoding: UTF-8
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":11}]'
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:51 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '905'
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "252d5c1e-ede2-460f-93d5-f33be9becd07", "action": "DeviceRouter",
+        "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
+        null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
+        null, "collector": "localhost", "osModel": null, "productionState": 400, "systems":
+        [], "priority": 3, "hwModel": null, "tagNumber": "", "osManufacturer": null,
+        "location": null, "groups": [], "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice",
+        "ipAddress": null, "events": {"info": {"count": 0, "acknowledged_count": 0},
+        "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
+        0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
+        0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
+        "name": "UnitTestDevice"}]}, "tid": 11, "type": "rpc", "method": "getDevices"}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:51 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/zport/dmd/zport/dmd/Devices/Server/devices/UnitTestDevice/sysUpTime
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:51 GMT
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '2'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 19 Feb 2019 22:36:52 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: "-1"
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:52 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/zport/dmd/zport/dmd/Devices/Server/devices/UnitTestDevice/sysUpTime
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:52 GMT
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '2'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 19 Feb 2019 22:36:52 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: "-1"
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:52 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/6_2_1_test_0003_returns_an_Array_of_events_for_a_device.yml
+++ b/test/fixtures/vcr_cassettes/6_2_1_test_0003_returns_an_Array_of_events_for_a_device.yml
@@ -1,0 +1,100 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    body:
+      encoding: UTF-8
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":12}]'
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:52 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:52 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '905'
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "4c63f583-5a2f-4b72-90e0-a9cd34f011f9", "action": "DeviceRouter",
+        "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
+        null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
+        null, "collector": "localhost", "osModel": null, "productionState": 400, "systems":
+        [], "priority": 3, "hwModel": null, "tagNumber": "", "osManufacturer": null,
+        "location": null, "groups": [], "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice",
+        "ipAddress": null, "events": {"info": {"count": 0, "acknowledged_count": 0},
+        "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
+        0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
+        0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
+        "name": "UnitTestDevice"}]}, "tid": 12, "type": "rpc", "method": "getDevices"}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:52 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/evconsole_router
+    body:
+      encoding: UTF-8
+      string: '[{"action":"EventsRouter","method":"query","data":[{"limit":100,"start":0,"sort":"lastTime","dir":"DESC","uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":13}]'
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:52 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:52 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "1", "action": "EventsRouter", "result": {"totalCount": 1,
+        "events": [{"prodState": "Production", "dedupid": "fan", "eventKey": "1",
+        "evid": "1", "eventClass": {"uid": "/zport/dmd/Events/HW/Temparature/Fan"}}],
+        "success": true, "tid": 19, "type": "rpc", "method": "query"}}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:52 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/6_2_1_test_0004_returns_an_Array_of_historical_events_for_a_device.yml
+++ b/test/fixtures/vcr_cassettes/6_2_1_test_0004_returns_an_Array_of_historical_events_for_a_device.yml
@@ -1,0 +1,100 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    body:
+      encoding: UTF-8
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":14}]'
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:52 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:53 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '905'
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "fcbf5db4-6366-4df0-b9cc-d6f3193c0685", "action": "DeviceRouter",
+        "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
+        null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
+        null, "collector": "localhost", "osModel": null, "productionState": 400, "systems":
+        [], "priority": 3, "hwModel": null, "tagNumber": "", "osManufacturer": null,
+        "location": null, "groups": [], "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice",
+        "ipAddress": null, "events": {"info": {"count": 0, "acknowledged_count": 0},
+        "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
+        0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
+        0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
+        "name": "UnitTestDevice"}]}, "tid": 14, "type": "rpc", "method": "getDevices"}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:53 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/evconsole_router
+    body:
+      encoding: UTF-8
+      string: '[{"action":"EventsRouter","method":"query","data":[{"limit":100,"start":0,"sort":"lastTime","dir":"DESC","uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":15}]'
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:53 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:53 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "1", "action": "EventsRouter", "result": {"totalCount": 1,
+        "events": [{"prodState": "Production", "dedupid": "fan", "eventKey": "1",
+        "evid": "1", "eventClass": {"uid": "/zport/dmd/Events/HW/Temparature/Fan"}}],
+        "success": true, "tid": 19, "type": "rpc", "method": "query"}}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:53 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/6_2_1_test_0005_returns_info_for_a_device_in_the_form_of_a_Hash.yml
+++ b/test/fixtures/vcr_cassettes/6_2_1_test_0005_returns_info_for_a_device_in_the_form_of_a_Hash.yml
@@ -1,0 +1,265 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    body:
+      encoding: UTF-8
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":3}]'
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:49 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:49 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '904'
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "f5ca4548-184a-433b-9005-46bbc3e277d6", "action": "DeviceRouter",
+        "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
+        null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
+        null, "collector": "localhost", "osModel": null, "productionState": 400, "systems":
+        [], "priority": 3, "hwModel": null, "tagNumber": "", "osManufacturer": null,
+        "location": null, "groups": [], "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice",
+        "ipAddress": null, "events": {"info": {"count": 0, "acknowledged_count": 0},
+        "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
+        0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
+        0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
+        "name": "UnitTestDevice"}]}, "tid": 3, "type": "rpc", "method": "getDevices"}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:49 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    body:
+      encoding: UTF-8
+      string: '[{"action":"DeviceRouter","method":"getInfo","data":[{"uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":4}]'
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:49 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:49 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "1c49bcdd-2284-41e6-abc4-5844c3f90da0", "action": "DeviceRouter",
+        "result": {"disabled": false, "data": {"productionState": 400, "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice",
+        "links": "", "snmpContact": "", "osModel": "", "snmpVersion": "v2c", "hwModel":
+        "", "osManufacturer": "", "deviceClass": {"connectionInfo": ["zSnmpCommunity"],
+        "uuid": "948d8770-4c36-47b9-94f0-9139fa8f9e94", "name": "Server", "severity":
+        "warning", "id": "Server", "meta_type": "DeviceClass", "inspector_type": "DeviceClass",
+        "uid": "/zport/dmd/Devices/Server", "events": {"info": {"count": 22, "acknowledged_count":
+        10}, "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count":
+        1, "acknowledged_count": 0}, "critical": {"count": 0, "acknowledged_count":
+        0}, "error": {"count": 0, "acknowledged_count": 0}, "debug": {"count": 0,
+        "acknowledged_count": 0}}, "description": ""}, "hwManufacturer": "", "docker_version":
+        "", "created_timestamp": 1550510987.859867, "renameInProgress": false, "collector":
+        "localhost", "id": "UnitTestDevice", "deviceConnectionInfo": "", "uptime":
+        "Unknown", "severity": "clear", "locking": {"updates": false, "deletion":
+        false, "events": false}, "comments": "", "name": "UnitTestDevice", "priority":
+        3, "snmpCommunity": "", "location": "", "memory": {"ram": "Unknown", "swap":
+        "Unknown"}, "icon": "/zport/dmd/img/icons/server.png", "priorityLabel": "Normal",
+        "lastCollected": "Not Modeled", "events": {"info": {"count": 0, "acknowledged_count":
+        0}, "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0,
+        "acknowledged_count": 0}, "critical": {"count": 0, "acknowledged_count": 0},
+        "error": {"count": 0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count":
+        0}}, "systems": [], "status": "", "ipAddressString": "", "description": "",
+        "snmpDescr": "", "groups": [], "device": "UnitTestDevice", "sshLink": "",
+        "firstSeen": 1550510987.859867, "snmpSysName": "", "pythonClass": "Products.ZenModel.Device",
+        "lastChanged": 1550535660.45533, "productionStateLabel": "Test", "serialNumber":
+        "", "uuid": "94251860-157a-4dd1-8386-33fa1db0d593", "tagNumber": "", "meta_type":
+        "Device", "inspector_type": "Device", "snmpLocation": "", "snmpAgent": "",
+        "ipAddress": "", "rackSlot": 0}, "success": true}, "tid": 4, "type": "rpc",
+        "method": "getInfo"}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:49 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    body:
+      encoding: UTF-8
+      string: '[{"action":"DeviceRouter","method":"getInfo","data":[{"uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":5}]'
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:49 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:50 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "739abdfd-057e-4c92-b5ac-fca0b764389b", "action": "DeviceRouter",
+        "result": {"disabled": false, "data": {"productionState": 400, "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice",
+        "links": "", "snmpContact": "", "osModel": "", "snmpVersion": "v2c", "hwModel":
+        "", "osManufacturer": "", "deviceClass": {"connectionInfo": ["zSnmpCommunity"],
+        "uuid": "948d8770-4c36-47b9-94f0-9139fa8f9e94", "name": "Server", "severity":
+        "warning", "id": "Server", "meta_type": "DeviceClass", "inspector_type": "DeviceClass",
+        "uid": "/zport/dmd/Devices/Server", "events": {"info": {"count": 22, "acknowledged_count":
+        10}, "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count":
+        1, "acknowledged_count": 0}, "critical": {"count": 0, "acknowledged_count":
+        0}, "error": {"count": 0, "acknowledged_count": 0}, "debug": {"count": 0,
+        "acknowledged_count": 0}}, "description": ""}, "hwManufacturer": "", "docker_version":
+        "", "created_timestamp": 1550510987.859867, "renameInProgress": false, "collector":
+        "localhost", "id": "UnitTestDevice", "deviceConnectionInfo": "", "uptime":
+        "Unknown", "severity": "clear", "locking": {"updates": false, "deletion":
+        false, "events": false}, "comments": "", "name": "UnitTestDevice", "priority":
+        3, "snmpCommunity": "", "location": "", "memory": {"ram": "Unknown", "swap":
+        "Unknown"}, "icon": "/zport/dmd/img/icons/server.png", "priorityLabel": "Normal",
+        "lastCollected": "Not Modeled", "events": {"info": {"count": 0, "acknowledged_count":
+        0}, "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0,
+        "acknowledged_count": 0}, "critical": {"count": 0, "acknowledged_count": 0},
+        "error": {"count": 0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count":
+        0}}, "systems": [], "status": "", "ipAddressString": "", "description": "",
+        "snmpDescr": "", "groups": [], "device": "UnitTestDevice", "sshLink": "",
+        "firstSeen": 1550510987.859867, "snmpSysName": "", "pythonClass": "Products.ZenModel.Device",
+        "lastChanged": 1550535660.45533, "productionStateLabel": "Test", "serialNumber":
+        "", "uuid": "94251860-157a-4dd1-8386-33fa1db0d593", "tagNumber": "", "meta_type":
+        "Device", "inspector_type": "Device", "snmpLocation": "", "snmpAgent": "",
+        "ipAddress": "", "rackSlot": 0}, "success": true}, "tid": 5, "type": "rpc",
+        "method": "getInfo"}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:50 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    body:
+      encoding: UTF-8
+      string: '[{"action":"DeviceRouter","method":"getInfo","data":[{"uid":"/zport/dmd/Devices/Server/devices/UnitTestDevice"}],"type":"rpc","tid":6}]'
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:50 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:50 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "e0ecd463-6c7c-40df-be7e-19851cb23d6c", "action": "DeviceRouter",
+        "result": {"disabled": false, "data": {"productionState": 400, "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice",
+        "links": "", "snmpContact": "", "osModel": "", "snmpVersion": "v2c", "hwModel":
+        "", "osManufacturer": "", "deviceClass": {"connectionInfo": ["zSnmpCommunity"],
+        "uuid": "948d8770-4c36-47b9-94f0-9139fa8f9e94", "name": "Server", "severity":
+        "warning", "id": "Server", "meta_type": "DeviceClass", "inspector_type": "DeviceClass",
+        "uid": "/zport/dmd/Devices/Server", "events": {"info": {"count": 22, "acknowledged_count":
+        10}, "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count":
+        1, "acknowledged_count": 0}, "critical": {"count": 0, "acknowledged_count":
+        0}, "error": {"count": 0, "acknowledged_count": 0}, "debug": {"count": 0,
+        "acknowledged_count": 0}}, "description": ""}, "hwManufacturer": "", "docker_version":
+        "", "created_timestamp": 1550510987.859867, "renameInProgress": false, "collector":
+        "localhost", "id": "UnitTestDevice", "deviceConnectionInfo": "", "uptime":
+        "Unknown", "severity": "clear", "locking": {"updates": false, "deletion":
+        false, "events": false}, "comments": "", "name": "UnitTestDevice", "priority":
+        3, "snmpCommunity": "", "location": "", "memory": {"ram": "Unknown", "swap":
+        "Unknown"}, "icon": "/zport/dmd/img/icons/server.png", "priorityLabel": "Normal",
+        "lastCollected": "Not Modeled", "events": {"info": {"count": 0, "acknowledged_count":
+        0}, "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0,
+        "acknowledged_count": 0}, "critical": {"count": 0, "acknowledged_count": 0},
+        "error": {"count": 0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count":
+        0}}, "systems": [], "status": "", "ipAddressString": "", "description": "",
+        "snmpDescr": "", "groups": [], "device": "UnitTestDevice", "sshLink": "",
+        "firstSeen": 1550510987.859867, "snmpSysName": "", "pythonClass": "Products.ZenModel.Device",
+        "lastChanged": 1550535660.45533, "productionStateLabel": "Test", "serialNumber":
+        "", "uuid": "94251860-157a-4dd1-8386-33fa1db0d593", "tagNumber": "", "meta_type":
+        "Device", "inspector_type": "Device", "snmpLocation": "", "snmpAgent": "",
+        "ipAddress": "", "rackSlot": 0}, "success": true}, "tid": 6, "type": "rpc",
+        "method": "getInfo"}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:50 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/6_2_1_test_0006_returns_an_Array_of_events_for_all_devices.yml
+++ b/test/fixtures/vcr_cassettes/6_2_1_test_0006_returns_an_Array_of_events_for_all_devices.yml
@@ -1,0 +1,100 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    body:
+      encoding: UTF-8
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":18}]'
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:53 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:53 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '905'
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "b735399e-ecb3-4029-9aa8-995aa42a33c3", "action": "DeviceRouter",
+        "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
+        null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
+        null, "collector": "localhost", "osModel": null, "productionState": 400, "systems":
+        [], "priority": 3, "hwModel": null, "tagNumber": "", "osManufacturer": null,
+        "location": null, "groups": [], "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice",
+        "ipAddress": null, "events": {"info": {"count": 0, "acknowledged_count": 0},
+        "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
+        0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
+        0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
+        "name": "UnitTestDevice"}]}, "tid": 18, "type": "rpc", "method": "getDevices"}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:53 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/evconsole_router
+    body:
+      encoding: UTF-8
+      string: '[{"action":"EventsRouter","method":"query","data":[{"limit":100,"start":0,"sort":"lastTime","dir":"DESC"}],"type":"rpc","tid":19}]'
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:53 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:54 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "1", "action": "EventsRouter", "result": {"totalCount": 1,
+        "events": [{"prodState": "Production", "dedupid": "fan", "eventKey": "1",
+        "evid": "1", "eventClass": {"uid": "/zport/dmd/Events/HW/Temparature/Fan"}}],
+        "success": true, "tid": 19, "type": "rpc", "method": "query"}}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:54 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/6_2_1_test_0007_fetches_the_report_tree.yml
+++ b/test/fixtures/vcr_cassettes/6_2_1_test_0007_fetches_the_report_tree.yml
@@ -1,0 +1,164 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    body:
+      encoding: UTF-8
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":9}]'
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:51 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '904'
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "ae0a0972-7413-4995-8129-e279a35d8572", "action": "DeviceRouter",
+        "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
+        null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
+        null, "collector": "localhost", "osModel": null, "productionState": 400, "systems":
+        [], "priority": 3, "hwModel": null, "tagNumber": "", "osManufacturer": null,
+        "location": null, "groups": [], "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice",
+        "ipAddress": null, "events": {"info": {"count": 0, "acknowledged_count": 0},
+        "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
+        0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
+        0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
+        "name": "UnitTestDevice"}]}, "tid": 9, "type": "rpc", "method": "getDevices"}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:51 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/report_router
+    body:
+      encoding: UTF-8
+      string: '[{"action":"ReportRouter","method":"asyncGetTree","data":["/zport/dmd/Reports"],"type":"rpc","tid":10}]'
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:51 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "a359c5df-a88d-422b-b31e-dd08f13d82a5", "action": "ReportRouter",
+        "result": [{"leaf": false, "uid": "/zport/dmd/Reports", "text": {"count":
+        69, "text": "Reports", "description": "reports"}, "children": [{"leaf": false,
+        "uid": "/zport/dmd/Reports/AWS Reports", "text": {"count": 1, "text": "AWS
+        Reports", "description": "reports"}, "deletable": true, "iconCls": "severity-icon-small
+        clear", "path": "Reports/AWS Reports", "hidden": false, "id": ".zport.dmd.Reports.AWS
+        Reports", "edit_url": null}, {"leaf": false, "uid": "/zport/dmd/Reports/Azure",
+        "text": {"count": 1, "text": "Azure", "description": "reports"}, "deletable":
+        true, "iconCls": "severity-icon-small clear", "path": "Reports/Azure", "hidden":
+        false, "id": ".zport.dmd.Reports.Azure", "edit_url": null}, {"leaf": false,
+        "uid": "/zport/dmd/Reports/Cisco UCS Reports", "text": {"count": 2, "text":
+        "Cisco UCS Reports", "description": "reports"}, "deletable": true, "iconCls":
+        "severity-icon-small clear", "path": "Reports/Cisco UCS Reports", "hidden":
+        false, "id": ".zport.dmd.Reports.Cisco UCS Reports", "edit_url": null}, {"leaf":
+        false, "uid": "/zport/dmd/Reports/Configuration Management", "text": {"count":
+        2, "text": "Configuration Management", "description": "reports"}, "deletable":
+        true, "iconCls": "severity-icon-small clear", "path": "Reports/Configuration
+        Management", "hidden": false, "id": ".zport.dmd.Reports.Configuration Management",
+        "edit_url": null}, {"leaf": false, "uid": "/zport/dmd/Reports/Custom Device
+        Reports", "text": {"count": 1, "text": "Custom Device Reports", "description":
+        "reports"}, "deletable": false, "iconCls": "severity-icon-small clear", "path":
+        "Reports/Custom Device Reports", "hidden": false, "id": ".zport.dmd.Reports.Custom
+        Device Reports", "edit_url": null}, {"leaf": false, "uid": "/zport/dmd/Reports/Device
+        Reports", "text": {"count": 12, "text": "Device Reports", "description": "reports"},
+        "deletable": true, "iconCls": "severity-icon-small clear", "path": "Reports/Device
+        Reports", "hidden": false, "id": ".zport.dmd.Reports.Device Reports", "edit_url":
+        null}, {"leaf": false, "uid": "/zport/dmd/Reports/Enterprise Reports", "text":
+        {"count": 15, "text": "Enterprise Reports", "description": "reports"}, "deletable":
+        true, "iconCls": "severity-icon-small clear", "path": "Reports/Enterprise
+        Reports", "hidden": false, "id": ".zport.dmd.Reports.Enterprise Reports",
+        "edit_url": null}, {"leaf": false, "uid": "/zport/dmd/Reports/Event Reports",
+        "text": {"count": 4, "text": "Event Reports", "description": "reports"}, "deletable":
+        true, "iconCls": "severity-icon-small clear", "path": "Reports/Event Reports",
+        "hidden": false, "id": ".zport.dmd.Reports.Event Reports", "edit_url": null},
+        {"leaf": false, "uid": "/zport/dmd/Reports/Graph Reports", "text": {"count":
+        5, "text": "Graph Reports", "description": "reports"}, "deletable": false,
+        "iconCls": "severity-icon-small clear", "path": "Reports/Graph Reports", "hidden":
+        false, "id": ".zport.dmd.Reports.Graph Reports", "edit_url": null}, {"leaf":
+        false, "uid": "/zport/dmd/Reports/Juniper ERX", "text": {"count": 1, "text":
+        "Juniper ERX", "description": "reports"}, "deletable": true, "iconCls": "severity-icon-small
+        clear", "path": "Reports/Juniper ERX", "hidden": false, "id": ".zport.dmd.Reports.Juniper
+        ERX", "edit_url": null}, {"leaf": false, "uid": "/zport/dmd/Reports/Monitoring
+        Capabilities Reports", "text": {"count": 1, "text": "Monitoring Capabilities
+        Reports", "description": "reports"}, "deletable": true, "iconCls": "severity-icon-small
+        clear", "path": "Reports/Monitoring Capabilities Reports", "hidden": false,
+        "id": ".zport.dmd.Reports.Monitoring Capabilities Reports", "edit_url": null},
+        {"leaf": false, "uid": "/zport/dmd/Reports/Multi-Graph Reports", "text": {"count":
+        5, "text": "Multi-Graph Reports", "description": "reports"}, "deletable":
+        false, "iconCls": "severity-icon-small clear", "path": "Reports/Multi-Graph
+        Reports", "hidden": false, "id": ".zport.dmd.Reports.Multi-Graph Reports",
+        "edit_url": null}, {"leaf": false, "uid": "/zport/dmd/Reports/Performance
+        Reports", "text": {"count": 7, "text": "Performance Reports", "description":
+        "reports"}, "deletable": true, "iconCls": "severity-icon-small clear", "path":
+        "Reports/Performance Reports", "hidden": false, "id": ".zport.dmd.Reports.Performance
+        Reports", "edit_url": null}, {"leaf": false, "uid": "/zport/dmd/Reports/Storage",
+        "text": {"count": 3, "text": "Storage", "description": "reports"}, "deletable":
+        true, "iconCls": "severity-icon-small clear", "path": "Reports/Storage", "hidden":
+        false, "id": ".zport.dmd.Reports.Storage", "edit_url": null}, {"leaf": false,
+        "uid": "/zport/dmd/Reports/vSphere", "text": {"count": 8, "text": "vSphere",
+        "description": "reports"}, "deletable": true, "iconCls": "severity-icon-small
+        clear", "path": "Reports/vSphere", "hidden": false, "id": ".zport.dmd.Reports.vSphere",
+        "edit_url": null}, {"leaf": true, "uid": "/zport/dmd/Reports/96", "text":
+        "96", "columns": 1, "deletable": true, "isGraphReport": false, "isMultiGraphReport":
+        true, "hidden": false, "path": "Reports/96", "id": ".zport.dmd.Reports.96",
+        "edit_url": "/zport/dmd/Reports/96/editMultiGraphReport", "iconCls": "leaf"}],
+        "deletable": false, "iconCls": "severity-icon-small clear", "path": "Reports",
+        "hidden": false, "id": ".zport.dmd.Reports", "edit_url": null}], "tid": 10,
+        "type": "rpc", "method": "asyncGetTree"}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:51 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/6_2_1_test_0008_fetches_available_report_types_and_returns_a_Hash.yml
+++ b/test/fixtures/vcr_cassettes/6_2_1_test_0008_fetches_available_report_types_and_returns_a_Hash.yml
@@ -1,0 +1,100 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    body:
+      encoding: UTF-8
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":16}]'
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:53 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:53 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '905'
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "b9b81b35-3cfd-4fc0-a7ad-b16938b99d65", "action": "DeviceRouter",
+        "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
+        null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
+        null, "collector": "localhost", "osModel": null, "productionState": 400, "systems":
+        [], "priority": 3, "hwModel": null, "tagNumber": "", "osManufacturer": null,
+        "location": null, "groups": [], "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice",
+        "ipAddress": null, "events": {"info": {"count": 0, "acknowledged_count": 0},
+        "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
+        0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
+        0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
+        "name": "UnitTestDevice"}]}, "tid": 16, "type": "rpc", "method": "getDevices"}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:53 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/report_router
+    body:
+      encoding: UTF-8
+      string: '[{"action":"ReportRouter","method":"getReportTypes","data":{},"type":"rpc","tid":17}]'
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:53 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:53 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '307'
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "08c5bc38-197e-4adf-b1e2-e73c9b27ec35", "action": "ReportRouter",
+        "result": {"menuText": ["Custom Device Report", "Graph Report", "Multi-Graph
+        Report"], "reportTypes": ["customDeviceReport", "graphReport", "multiGraphReport"],
+        "success": true}, "tid": 17, "type": "rpc", "method": "getReportTypes"}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:53 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/6_2_1_test_0009_renames_the_device.yml
+++ b/test/fixtures/vcr_cassettes/6_2_1_test_0009_renames_the_device.yml
@@ -1,0 +1,184 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    body:
+      encoding: UTF-8
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"UnitTestDevice"}}],"type":"rpc","tid":20}]'
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:54 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:55 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '905'
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "bf5f4de2-a82e-475e-bc95-a78d718f445a", "action": "DeviceRouter",
+        "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
+        null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
+        null, "collector": "localhost", "osModel": null, "productionState": 400, "systems":
+        [], "priority": 3, "hwModel": null, "tagNumber": "", "osManufacturer": null,
+        "location": null, "groups": [], "uid": "/zport/dmd/Devices/Server/devices/UnitTestDevice",
+        "ipAddress": null, "events": {"info": {"count": 0, "acknowledged_count": 0},
+        "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
+        0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
+        0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
+        "name": "UnitTestDevice"}]}, "tid": 20, "type": "rpc", "method": "getDevices"}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:55 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/zport/dmd/zport/dmd/Devices/Server/devices/UnitTestDevice/renameDevice?newId=unit_test_temporary_device_name
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:55 GMT
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '65'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 19 Feb 2019 22:36:56 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: "/zport/dmd/Devices/Server/devices/unit_test_temporary_device_name"
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:56 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/zport/dmd/zport/dmd/device_router
+    body:
+      encoding: UTF-8
+      string: '[{"action":"DeviceRouter","method":"getDevices","data":[{"uid":"/zport/dmd/Devices","params":{"name":"unit_test_temporary_device_name"}}],"type":"rpc","tid":21}]'
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:56 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Feb 2019 22:36:57 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '939'
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: '{"uuid": "6a913108-bbb3-45dd-927c-936a381fb5b7", "action": "DeviceRouter",
+        "result": {"totalCount": 1, "hash": "1", "success": true, "devices": [{"ipAddressString":
+        null, "serialNumber": "", "pythonClass": "Products.ZenModel.Device", "hwManufacturer":
+        null, "collector": "localhost", "osModel": null, "productionState": 400, "systems":
+        [], "priority": 3, "hwModel": null, "tagNumber": "", "osManufacturer": null,
+        "location": null, "groups": [], "uid": "/zport/dmd/Devices/Server/devices/unit_test_temporary_device_name",
+        "ipAddress": null, "events": {"info": {"count": 0, "acknowledged_count": 0},
+        "clear": {"count": 0, "acknowledged_count": 0}, "warning": {"count": 0, "acknowledged_count":
+        0}, "critical": {"count": 0, "acknowledged_count": 0}, "error": {"count":
+        0, "acknowledged_count": 0}, "debug": {"count": 0, "acknowledged_count": 0}},
+        "name": "unit_test_temporary_device_name"}]}, "tid": 21, "type": "rpc", "method":
+        "getDevices"}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:57 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/zport/dmd/zport/dmd/Devices/Server/devices/unit_test_temporary_device_name/renameDevice?newId=UnitTestDevice
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.3.3 (2016-11-21))
+      Accept:
+      - "*/*"
+      Date:
+      - Tue, 19 Feb 2019 22:36:57 GMT
+      Cookie: ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '48'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 19 Feb 2019 22:36:57 GMT
+      Server: ''
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Set-Cookie: ''
+    body:
+      encoding: UTF-8
+      string: "/zport/dmd/Devices/Server/devices/UnitTestDevice"
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 22:36:57 GMT
+recorded_with: VCR 4.0.0

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,4 +17,18 @@ WebMock.enable!
 VCR.configure do |config|
   config.cassette_library_dir = "test/fixtures/vcr_cassettes"
   config.hook_into :webmock
+
+  config.filter_sensitive_data('admin') { ZENOSS_USER }
+  config.filter_sensitive_data('http://localhost:8080/zport/dmd') { ZENOSS_URL }
+  config.filter_sensitive_data('zenoss') { ZENOSS_PASSWORD }
+
+  config.before_record do |interaction, cassette|
+    if cassette.name == '6.2.1_initial connection'
+      interaction.request.body = '__ac_name=admin&__ac_password=zenoss'\
+                                 '&submitted=true&came_from=https%3A%2F'\
+                                 '%2Fhttp:://localhost:8080/zport/dmd'\
+                                 '%2Fzport%2Fdmd'
+    end
+  end
 end
+

--- a/test/zenoss_client_test.rb
+++ b/test/zenoss_client_test.rb
@@ -11,7 +11,9 @@ describe Zenoss do
   def self.zen
     VCR.use_cassette "#{ZENOSS_VERSION}_initial connection", :match_requests_on => [:method, :path, :query]  do
       @zen ||= begin
-        connection = Zenoss.connect ZENOSS_URL, ZENOSS_USER, ZENOSS_PASSWORD
+        opts = {}
+        opts[:version] = ZENOSS_VERSION
+        connection = Zenoss.connect ZENOSS_URL, ZENOSS_USER, ZENOSS_PASSWORD, opts
         # We Need to Create A Device for testing
         # We do this here, so we can re-use the same device over and over
         # Without needing to create a new one per test


### PR DESCRIPTION
* Changes to test helper file. Set Zenoss version at 6.2.1, and filter sensitive data in recording files.
* Changes to `#get_report_tree` to support newer Zenoss API endpoint
* Adding in all test fixture data for Zenoss API version 6.2.1